### PR TITLE
Users can request erasure

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -22,11 +22,13 @@ return [
 
     (new Extend\Routes('api'))
         ->post('/gdpr/export', 'gdpr.request-export', Api\Controller\RequestExportController::class)
-        ->post('/user-erasure-requests', 'gdpr.erasure.create', Api\Controller\RequestErasureController::class),
+        ->post('/user-erasure-requests', 'gdpr.erasure.create', Api\Controller\RequestErasureController::class)
+        ->delete('/user-erasure-requests/{id}', 'gdpr.erasure.cancel', Api\Controller\CancelErasureController::class),
 
     (new Extend\Notification)
         ->type(Notifications\ExportAvailableBlueprint::class, ExportSerializer::class, ['alert', 'email'])
-        ->type(Notifications\ConfirmErasureBlueprint::class, RequestErasureSerializer::class, ['email']),
+        ->type(Notifications\ConfirmErasureBlueprint::class, RequestErasureSerializer::class, ['alert', 'email'])
+        ->type(Notifications\ErasureRequestCancelledBlueprint::class, RequestErasureSerializer::class, ['alert', 'email']),
 
     (new Extend\Model(User::class))
         ->hasOne('erasureRequest', ErasureRequest::class),

--- a/extend.php
+++ b/extend.php
@@ -4,8 +4,12 @@ namespace Blomstra\Gdpr;
 
 use Blomstra\Gdpr\Api\Serializer\ExportSerializer;
 use Blomstra\Gdpr\Api\Serializer\RequestErasureSerializer;
+use Blomstra\Gdpr\Models\ErasureRequest;
 use Blomstra\Gdpr\Notifications;
+use Flarum\Api\Controller\ShowUserController;
+use Flarum\Api\Serializer\UserSerializer;
 use Flarum\Extend;
+use Flarum\User\User;
 
 return [
     (new Extend\Frontend('forum'))->js(__DIR__ . '/js/dist/forum.js'),
@@ -13,16 +17,25 @@ return [
     (new Extend\Locales(__DIR__ . '/resources/locale')),
 
     (new Extend\Routes('forum'))
-        ->get('/gdpr/export/{file}', 'gdpr.export', Http\Controller\ExportController::class),
-        //->get('/gdpr/erasure/confirm/{token}', 'gdpr.erasure-confirm', NEWCONTROLLER),
+        ->get('/gdpr/export/{file}', 'gdpr.export', Http\Controller\ExportController::class)
+        ->get('/gdpr/erasure/confirm/{token}', 'gdpr.erasure.confirm', Http\Controller\ConfirmErasureController::class),
 
     (new Extend\Routes('api'))
         ->post('/gdpr/export', 'gdpr.request-export', Api\Controller\RequestExportController::class)
-        ->post('/gdpr/erase-me', 'gdpr.request-erasure', Api\Controller\RequestErasureController::class),
+        ->post('/user-erasure-requests', 'gdpr.erasure.create', Api\Controller\RequestErasureController::class),
 
     (new Extend\Notification)
         ->type(Notifications\ExportAvailableBlueprint::class, ExportSerializer::class, ['alert', 'email'])
         ->type(Notifications\ConfirmErasureBlueprint::class, RequestErasureSerializer::class, ['email']),
+
+    (new Extend\Model(User::class))
+        ->hasOne('erasureRequest', ErasureRequest::class),
+
+    (new Extend\ApiController(ShowUserController::class))
+        ->addInclude('erasureRequest'),
+
+    (new Extend\ApiSerializer(UserSerializer::class))
+        ->hasOne('erasureRequest', RequestErasureSerializer::class),
 
     (new Extend\View)->namespace('gdpr', __DIR__ . '/resources/views'),
 

--- a/extend.php
+++ b/extend.php
@@ -27,7 +27,7 @@ return [
 
     (new Extend\Notification)
         ->type(Notifications\ExportAvailableBlueprint::class, ExportSerializer::class, ['alert', 'email'])
-        ->type(Notifications\ConfirmErasureBlueprint::class, RequestErasureSerializer::class, ['alert', 'email'])
+        ->type(Notifications\ConfirmErasureBlueprint::class, RequestErasureSerializer::class, ['email'])
         ->type(Notifications\ErasureRequestCancelledBlueprint::class, RequestErasureSerializer::class, ['alert', 'email']),
 
     (new Extend\Model(User::class))

--- a/js/src/forum/components/RequestDataModal.js
+++ b/js/src/forum/components/RequestDataModal.js
@@ -1,10 +1,6 @@
 import Modal from 'flarum/components/Modal';
 import Button from 'flarum/components/Button';
 
-/**
- * The `ChangePasswordModal` component shows a modal dialog which allows the
- * user to send themself a password reset email.
- */
 export default class RequestDataModal extends Modal {
     className() {
         return 'RequestDataModal Modal--small';

--- a/js/src/forum/components/RequestErasureModal.js
+++ b/js/src/forum/components/RequestErasureModal.js
@@ -1,0 +1,112 @@
+import Modal from 'flarum/components/Modal';
+import Button from 'flarum/components/Button';
+import extractText from 'flarum/utils/extractText';
+import ItemList from 'flarum/utils/ItemList';
+import Stream from 'flarum/utils/Stream';
+
+export default class RequestErasureModal extends Modal {
+    oninit(vnode) {
+        super.oninit(vnode);
+
+        this.reason = Stream("");
+        this.password = Stream("");
+    }
+
+    className() {
+        return 'RequestErasureModal Modal--small';
+    }
+
+    title() {
+        return app.translator.trans('blomstra-gdpr.forum.request_erasure.title');
+    }
+
+    content() {
+        return (
+            <div className="Modal-body">
+                <div className="Form Form--centered">
+                    {this.fields().toArray()}
+                </div>
+            </div>
+        );
+    }
+
+    fields() {
+        const items = new ItemList();
+
+        items.add(
+            'text',
+            <p className="helpText">{app.translator.trans('blomstra-gdpr.forum.request_erasure.text')}</p>
+        )
+
+        const currRequest = app.session.user.erasureRequest();
+
+        if (currRequest) {
+            items.add(
+                'status',
+                <div className="Form-group">
+                    <p className="helpText">{app.translator.trans('blomstra-gdpr.forum.request_erasure.status', {
+                        status: currRequest.status()
+                    })}</p>
+                </div>
+            );
+        } else {
+            items.add(
+                'password',
+                <div className="Form-group">
+                    <input
+                        type="password"
+                        className="FormControl"
+                        bidi={this.password}
+                        placeholder={extractText(app.translator.trans('blomstra-gdpr.forum.request_erasure.password_label'))}
+                    />
+                </div>
+            );
+
+            items.add(
+                'reason',
+                <div className="Form-group">
+                    <textarea
+                        className="FormControl"
+                        bidi={this.reason}
+                        placeholder={extractText(app.translator.trans('blomstra-gdpr.forum.request_erasure.reason_label'))}
+                    ></textarea>
+                </div>
+            );
+
+            items.add(
+                'submit',
+                <div className="Form-group">
+                    {Button.component({
+                        className: 'Button Button--primary Button--block',
+                        type: 'submit',
+                        loading: this.loading,
+                    }, app.translator.trans('blomstra-gdpr.forum.request_erasure.request_button'))}
+                </div>
+            );
+        }
+
+        return items;
+    }
+
+    data() {
+        return {
+            attributes: { reason: this.reason() },
+            relationships: { user: app.session.user }
+        }
+    }
+
+    onsubmit(e) {
+        e.preventDefault();
+
+        this.loading = true;
+
+        app.store
+            .createRecord('user-erasure-requests')
+            .save(this.data(), { meta: { password: this.password() } })
+            .then(this.hide.bind(this))
+            .catch(() => {
+                this.loading = false;
+                m.redraw();
+            });
+    }
+}

--- a/js/src/forum/components/RequestErasureModal.js
+++ b/js/src/forum/components/RequestErasureModal.js
@@ -51,6 +51,17 @@ export default class RequestErasureModal extends Modal {
                     </div>
                 );
             }
+
+            items.add(
+                'cancel',
+                <div className="Form-group">
+                    {Button.component({
+                        className: 'Button Button--primary Button--block',
+                        onclick: this.oncancel.bind(this),
+                        loading: this.loading,
+                    }, app.translator.trans('blomstra-gdpr.forum.request_erasure.cancel_button'))}
+                </div>
+            );
         } else {
             items.add(
                 'text',
@@ -96,6 +107,19 @@ export default class RequestErasureModal extends Modal {
         return items;
     }
 
+    oncancel(e) {
+        this.loading = true;
+        m.redraw();
+
+        app.session.user
+            .erasureRequest()
+            .delete()
+            .then(() => {
+                this.loading = false;
+                m.redraw();
+            });
+    }
+
     data() {
         // Status is set so that the proper confirmation message is displayed.
         return {
@@ -115,6 +139,7 @@ export default class RequestErasureModal extends Modal {
             .save(this.data(), { meta: { password: this.password() } })
             .then(erasureRequest => {
                 app.session.user.pushData({ relationships: { erasureRequest } });
+                this.loading = false;
                 m.redraw();
             })
             .catch(() => {

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -1,11 +1,27 @@
 import { extend } from 'flarum/extend';
+import Model from 'flarum/common/Model';
 import SettingsPage from 'flarum/components/SettingsPage';
 import Button from 'flarum/components/Button';
 import RequestDataModal from './components/RequestDataModal';
+import RequestErasureModal from './components/RequestErasureModal';
+import ErasureRequest from './models/ErasureRequest';
 
 app.initializers.add(
     'blomstra-gdpr',
     () => {
+        app.store.models['user-erasure-requests'] = ErasureRequest;
+        app.store.models.users.prototype.erasureRequest = Model.hasOne('erasureRequest');
+
+        extend(SettingsPage.prototype, 'accountItems', function (items) {
+            items.add(
+                'gdprErasure',
+                Button.component({
+                    className: 'Button',
+                    onclick: () => app.modal.show(RequestErasureModal),
+                }, app.translator.trans('blomstra-gdpr.forum.settings.request_erasure_button'))
+            );
+        });
+
         extend(SettingsPage.prototype, 'accountItems', function (items) {
             items.add(
                 'gdprExport',

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -1,16 +1,25 @@
 import { extend } from 'flarum/extend';
 import Model from 'flarum/common/Model';
+import Page from 'flarum/components/Page';
 import SettingsPage from 'flarum/components/SettingsPage';
 import Button from 'flarum/components/Button';
 import RequestDataModal from './components/RequestDataModal';
 import RequestErasureModal from './components/RequestErasureModal';
 import ErasureRequest from './models/ErasureRequest';
 
+
 app.initializers.add(
     'blomstra-gdpr',
     () => {
         app.store.models['user-erasure-requests'] = ErasureRequest;
         app.store.models.users.prototype.erasureRequest = Model.hasOne('erasureRequest');
+
+
+        extend(Page.prototype, 'oninit', function () {
+            if (m.route.param('erasureRequestConfirmed')) {
+                app.alerts.show({ type: 'success' }, app.translator.trans('blomstra-gdpr.forum.erasure_request_confirmed'));
+            }
+        });
 
         extend(SettingsPage.prototype, 'accountItems', function (items) {
             items.add(

--- a/js/src/forum/models/ErasureRequest.js
+++ b/js/src/forum/models/ErasureRequest.js
@@ -1,0 +1,15 @@
+import Model from 'flarum/common/Model';
+
+export default class ErasureRequest extends Model { }
+
+Object.assign(ErasureRequest.prototype, {
+    status: Model.attribute('status'),
+    reason: Model.attribute('reason'),
+    createdAt: Model.attribute('createdAt', Model.transformDate),
+    userConfirmedAt: Model.attribute('userConfirmedAt', Model.transformDate),
+    processedAt: Model.attribute('processedAt', Model.transformDate),
+    processorComment: Model.attribute('processorComment'),
+
+    user: Model.hasOne('user'),
+    processedBy: Model.hasOne('processedBy'),
+});

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -11,6 +11,13 @@ blomstra-gdpr:
 
                 {erasure_confirm_url}
 
+        erasure_cancelled:
+            subject: Account erasure request cancelled
+            body: |
+                Hey {display_name}!
+
+                This is an automatic notification that you have successfully cancelled your account erasure request.
+
         export_available:
             subject: Data export available
             body: |
@@ -45,4 +52,5 @@ blomstra-gdpr:
             text: Once received and confirmed, an admin will review your request within 30 days, as required by the GDPR.
             password_label: Confirm Password
             reason_label: Reason (optional)
+            cancel_button: Cancel request
             request_button: Request erasure

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -36,10 +36,13 @@ blomstra-gdpr:
             request_button: Request archive
         request_erasure:
             title: Request account erasure
-            status: |
-                Your request has been received. It currently has status: <strong>{status}</strong>.
-            text: >
-                An admin will review your request within 30 days, as required by the GDPR.
+            reason: "You provided the following reason: {reason}"
+            status:
+                awaiting_user_confirmation: |
+                    You should have received an email to confirm your account erasure request.
+                user_confirmed: |
+                    You have confirmed your account erasure request. Action will be taken within 30 days, as required by the GDPR.
+            text: Once received and confirmed, an admin will review your request within 30 days, as required by the GDPR.
             password_label: Confirm Password
             reason_label: Reason (optional)
             request_button: Request erasure

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -25,6 +25,7 @@ blomstra-gdpr:
     forum:
         settings:
             export_data_button: Export Data
+            request_erasure_button: Erase Account
         request_data:
             title: Request your data
             text: >
@@ -32,3 +33,12 @@ blomstra-gdpr:
                 an email will be send to you with a link to retrieve
                 this archive. The link will remain active for one day.
             request_button: Request archive
+        request_erasure:
+            title: Request account erasure
+            status: |
+                Your request has been received. It currently has status: <strong>{status}</strong>.
+            text: >
+                An admin will review your request within 30 days, as required by the GDPR.
+            password_label: Confirm Password
+            reason_label: Reason (optional)
+            request_button: Request erasure

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -23,6 +23,7 @@ blomstra-gdpr:
                 This export will remain available until {destroys_at}.
 
     forum:
+        erasure_request_confirmed: You have confirmed your account erasure request. Action will be taken within 30 days, as required by the GDPR.
         settings:
             export_data_button: Export Data
             request_erasure_button: Erase Account

--- a/resources/views/confirm-erasure.blade.php
+++ b/resources/views/confirm-erasure.blade.php
@@ -1,4 +1,4 @@
 {!! $translator->trans('blomstra-gdpr.email.confirm_erasure.body', [
     "{display_name}" => $user->display_name,
-    "{erasure_confirm_url}" => $url->to('forum')->route('gdpr.erasure-confirm'),
+    "{erasure_confirm_url}" => $url->to('forum')->route('gdpr.erasure.confirm', ["token" => $blueprint->getSubject()->verification_token]),
 ]) !!}

--- a/resources/views/erasure-cancelled.blade.php
+++ b/resources/views/erasure-cancelled.blade.php
@@ -1,0 +1,3 @@
+{!! $translator->trans('blomstra-gdpr.email.erasure_cancelled.body', [
+    "{display_name}" => $user->display_name
+]) !!}

--- a/src/Api/Controller/CancelErasureController.php
+++ b/src/Api/Controller/CancelErasureController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Blomstra\Gdpr\Api\Controller;
+
+use Blomstra\Gdpr\Api\Serializer\RequestErasureSerializer;
+use Blomstra\Gdpr\Models\ErasureRequest;
+use Blomstra\Gdpr\Notifications\ErasureRequestCancelledBlueprint;
+use Flarum\Api\Controller\AbstractDeleteController;
+use Flarum\Notification\NotificationSyncer;
+use Flarum\User\Exception\PermissionDeniedException;
+use Flarum\User\User;
+use Illuminate\Support\Arr;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CancelErasureController extends AbstractDeleteController
+{
+    /**
+     * @var NotificationSyncer
+     */
+    protected $notifications;
+
+    public function __construct(NotificationSyncer $notifications) {
+        $this->notifications = $notifications;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(ServerRequestInterface $request)
+    {
+        /** @var User $actor */
+        $actor = $request->getAttribute('actor');
+
+        $id = Arr::get($request->getQueryParams(), 'id');
+        $erasureRequest = ErasureRequest::where('id', $id)->firstOrFail();
+
+        $isSelf = $actor->id === $erasureRequest->user_id;
+        $appropriateStatus = $erasureRequest->status === 'awaiting_user_confirmation' || $erasureRequest->status === 'user_confirmed';
+        if (!$isSelf || !$appropriateStatus) {
+            throw new PermissionDeniedException();
+        }
+
+        $this->notifications->sync(new ErasureRequestCancelledBlueprint($erasureRequest), [$actor]);
+    }
+}

--- a/src/Api/Controller/RequestErasureController.php
+++ b/src/Api/Controller/RequestErasureController.php
@@ -2,15 +2,16 @@
 
 namespace Blomstra\Gdpr\Api\Controller;
 
+use Blomstra\Gdpr\Api\Serializer\RequestErasureSerializer;
 use Blomstra\Gdpr\Models\ErasureRequest;
 use Blomstra\Gdpr\Notifications\ConfirmErasureBlueprint;
 use Flarum\Api\Controller\AbstractCreateController;
+use Flarum\Notification\NotificationSyncer;
 use Flarum\User\Exception\NotAuthenticatedException;
 use Flarum\User\User;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -22,9 +23,18 @@ class RequestErasureController extends AbstractCreateController
     public $serializer = RequestErasureSerializer::class;
 
     /**
+     * @var NotificationSyncer
+     */
+    protected $notifications;
+
+    public function __construct(NotificationSyncer $notifications) {
+        $this->notifications = $notifications;
+    }
+
+    /**
      * @inheritDoc
      */
-    public function data(ServerRequestInterface $request, Document $document): ResponseInterface
+    public function data(ServerRequestInterface $request, Document $document)
     {
         /** @var User $actor */
         $actor = $request->getAttribute('actor');

--- a/src/Api/Controller/RequestErasureController.php
+++ b/src/Api/Controller/RequestErasureController.php
@@ -45,7 +45,7 @@ class RequestErasureController extends AbstractCreateController
             throw new NotAuthenticatedException();
         }
 
-        $reason = $request->getAttribute('attributes.reason');
+        $reason = Arr::get($request->getParsedBody(), 'data.attributes.reason');
 
         $token = Str::random(40);
 
@@ -56,8 +56,8 @@ class RequestErasureController extends AbstractCreateController
         ]);
 
         $erasureRequest->user_id = $actor->id;
-        $erasureRequest->status = 'sent';
-        $erasureRequest->reason = empty($reason) ? null : $reason;
+        $erasureRequest->status = 'awaiting_user_confirmation';
+        $erasureRequest->reason = $reason;
         $erasureRequest->verification_token = $token;
         $erasureRequest->created_at = Carbon::now();
 

--- a/src/Api/Serializer/RequestErasureSerializer.php
+++ b/src/Api/Serializer/RequestErasureSerializer.php
@@ -10,7 +10,7 @@ class RequestErasureSerializer extends AbstractSerializer
     /**
      * {@inheritdoc}
      */
-    protected $type = 'user-erasure-request';
+    protected $type = 'user-erasure-requests';
 
     /**
      * {@inheritdoc}

--- a/src/Http/Controller/ConfirmErasureController.php
+++ b/src/Http/Controller/ConfirmErasureController.php
@@ -53,7 +53,7 @@ class ConfirmErasureController implements RequestHandlerInterface
         $erasureRequest = ErasureRequest::where('verification_token', $token)->first();
 
         $erasureRequest->user_confirmed_at = Carbon::now();
-        $erasureRequest->status = 'confirmed';
+        $erasureRequest->status = 'user_confirmed';
         $erasureRequest->save();
 
         $session = $request->getAttribute('session');

--- a/src/Http/Controller/ConfirmErasureController.php
+++ b/src/Http/Controller/ConfirmErasureController.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Blomstra\Gdpr\Http\Controller;
+
+use Blomstra\Gdpr\Models\ErasureRequest;
+use Carbon\Carbon;
+use Flarum\Http\UrlGenerator;
+use Flarum\User\Exception\PermissionDeniedException;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ConfirmErasureController implements RequestHandlerInterface
+{
+    /**
+     * @var UrlGenerator
+     */
+    protected $url;
+
+    /**
+     * @param UrlGenerator $url
+     */
+    public function __construct(UrlGenerator $url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * @param Request $request
+     * @return ResponseInterface
+     */
+    public function handle(Request $request): ResponseInterface
+    {
+        $actor = $request->getAttribute('actor');
+        $token = Arr::get($request->getQueryParams(), 'token');
+
+        $erasureRequest = ErasureRequest::where('verification_token', $token)->first();
+
+        if ($actor->id !== $erasureRequest->user_id) {
+            throw new PermissionDeniedException();
+        }
+
+        $erasureRequest->user_confirmed_at = Carbon::now();
+        $erasureRequest->status = 'confirmed';
+        $erasureRequest->save();
+
+        return new RedirectResponse($this->url->to('forum')->base());
+    }
+}

--- a/src/Notifications/ConfirmErasureBlueprint.php
+++ b/src/Notifications/ConfirmErasureBlueprint.php
@@ -3,6 +3,7 @@
 namespace Blomstra\Gdpr\Notifications;
 
 use Blomstra\Gdpr\Models\ErasureRequest;
+use Carbon\Carbon;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\MailableInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -41,7 +42,8 @@ class ConfirmErasureBlueprint implements BlueprintInterface, MailableInterface
     public function getData()
     {
         return [
-            'erasure-request' => $this->request->id
+            'erasure-request' => $this->request->id,
+            'timestamp' => Carbon::now()
         ];
     }
 
@@ -50,7 +52,7 @@ class ConfirmErasureBlueprint implements BlueprintInterface, MailableInterface
      */
     public static function getType()
     {
-        return 'user-erasure-requests';
+        return 'gdpr_erasure_confirm';
     }
 
     /**

--- a/src/Notifications/ConfirmErasureBlueprint.php
+++ b/src/Notifications/ConfirmErasureBlueprint.php
@@ -50,7 +50,7 @@ class ConfirmErasureBlueprint implements BlueprintInterface, MailableInterface
      */
     public static function getType()
     {
-        return 'user-erasure-request';
+        return 'user-erasure-requests';
     }
 
     /**

--- a/src/Notifications/ErasureRequestCancelledBlueprint.php
+++ b/src/Notifications/ErasureRequestCancelledBlueprint.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Blomstra\Gdpr\Notifications;
+
+use Blomstra\Gdpr\Models\ErasureRequest;
+use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Notification\MailableInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class ErasureRequestCancelledBlueprint implements BlueprintInterface, MailableInterface
+{
+/**
+     * @var ErasureRequest
+     */
+    private $request;
+
+    public function __construct(ErasureRequest $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFromUser()
+    {
+        return $this->request->user;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSubject()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getData()
+    {
+        return [
+            'erasure-request' => $this->request->id
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getType()
+    {
+        return 'gdpr_erasure_cancelled';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getSubjectModel()
+    {
+        return ErasureRequest::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getEmailView()
+    {
+        return 'gdpr::erasure-cancelled';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getEmailSubject(TranslatorInterface $translator)
+    {
+        return $translator->trans('blomstra-gdpr.email.erasure_cancelled.subject');
+    }
+}

--- a/src/Notifications/ErasureRequestCancelledBlueprint.php
+++ b/src/Notifications/ErasureRequestCancelledBlueprint.php
@@ -3,6 +3,7 @@
 namespace Blomstra\Gdpr\Notifications;
 
 use Blomstra\Gdpr\Models\ErasureRequest;
+use Carbon\Carbon;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\MailableInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -41,7 +42,8 @@ class ErasureRequestCancelledBlueprint implements BlueprintInterface, MailableIn
     public function getData()
     {
         return [
-            'erasure-request' => $this->request->id
+            'erasure-request' => $this->request->id,
+            'timestamp' => Carbon::now()
         ];
     }
 


### PR DESCRIPTION
TODO:

- [x] Better messages in UI for viewing status
- [x] Show some indication (alert?) that confirmation has succeeded
- [x] Users are unable to resend: we need either that, or the ability to cancel and create a new request (I think I prefer the latter, it's more versatile)