### PR TITLE
feat: translatable action descriptions, zipmanager, refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ return [
         ]),
 ];
 ```
+### Flarum extensions
+
+These are the known extensions which offer GDPR data integration with this extension. Don't see a required extension listed? Contact the author to request it
+
+- `fof/drafts`, since `1.2.8`
+- `fof/upload`, since `1.4.3`
+- `ianm/follow-users`, since `1.4.0`
 
 ### FAQ & Recommendations
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "extra": {
         "flarum-extension": {
-            "title": "GDPR",
+            "title": "GDPR Data Management",
             "category": "feature",
             "icon": {
                 "image": "resources/logo.svg",
@@ -61,7 +61,7 @@
                 "backendTesting": true,
                 "jsCommon": true
             }
-        }
+        } 
     },
     "autoload-dev": {
         "psr-4": {

--- a/extend.php
+++ b/extend.php
@@ -39,6 +39,7 @@ return [
     (new Extend\Routes('api'))
         ->remove('users.delete')
         ->delete('/users/{id}', 'users.delete', Api\Controller\DeleteUserController::class)
+        ->delete('/users/{id}/{mode}', 'users.delete.mode', Api\Controller\DeleteUserController::class)
         ->post('/gdpr/export', 'gdpr.request-export', Api\Controller\RequestExportController::class)
         ->get('/user-erasure-requests', 'gdpr.erasure.index', Api\Controller\ListErasureRequestsController::class)
         ->post('/user-erasure-requests', 'gdpr.erasure.create', Api\Controller\RequestErasureController::class)

--- a/extend.php
+++ b/extend.php
@@ -71,6 +71,7 @@ return [
     (new Extend\Settings())
         ->default('blomstra-gdpr.allow-anonymization', true)
         ->default('blomstra-gdpr.allow-deletion', false)
+        ->default('blomstra-gdpr.default-anonymous-username', 'Anonymous')
         ->default('blomstra-gdpr.default-erasure', ErasureRequest::MODE_ANONYMIZATION)
         ->serializeToForum('erasureAnonymizationAllowed', 'blomstra-gdpr.allow-anonymization', 'boolVal')
         ->serializeToForum('erasureDeletionAllowed', 'blomstra-gdpr.allow-deletion', 'boolVal'),

--- a/js/src/admin/GdprPage.tsx
+++ b/js/src/admin/GdprPage.tsx
@@ -6,6 +6,7 @@ import type Mithril from 'mithril';
 import DataType from './models/DataType';
 import Tooltip from 'flarum/common/components/Tooltip';
 import ExtensionLink from './components/ExtensionLink';
+import LinkButton from 'flarum/common/components/LinkButton';
 
 export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> extends AdminPage<CustomAttrs> {
   gdprDataTypes: DataType[] = [];
@@ -41,6 +42,12 @@ export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
 
     return (
       <div className="GdprPage">
+        <h3>{app.translator.trans('blomstra-gdpr.admin.gdpr_page.settings.heading')}</h3>
+        <p className="helpText">{app.translator.trans('blomstra-gdpr.admin.gdpr_page.settings.help_text')}</p>
+        <LinkButton className="Button" href={app.route('extension', { id: 'blomstra-gdpr' })}>
+          {app.translator.trans('blomstra-gdpr.admin.gdpr_page.settings.extension_settings_button')}
+        </LinkButton>
+        <hr />
         <h3>{app.translator.trans('blomstra-gdpr.admin.gdpr_page.data_types.title')}</h3>
         <p className="helpText">{app.translator.trans('blomstra-gdpr.admin.gdpr_page.data_types.help_text')}</p>
 
@@ -71,6 +78,7 @@ export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
             </>
           ))}
         </div>
+        <hr />
         <h3>{app.translator.trans('blomstra-gdpr.admin.gdpr_page.user_table_data.title')}</h3>
         <p className="helpText">{app.translator.trans('blomstra-gdpr.admin.gdpr_page.user_table_data.help_text')}</p>
         <div className="GdprUserColumnData">Not yet implemented</div>

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -29,6 +29,12 @@ app.initializers.add('blomstra-gdpr', () => {
         deletion: app.translator.trans('blomstra-gdpr.admin.settings.default_erasure_options.deletion'),
       },
     })
+    .registerSetting({
+      setting: 'blomstra-gdpr.default-anonymous-username',
+      type: 'string',
+      label: app.translator.trans('blomstra-gdpr.admin.settings.default_anonymous_username'),
+      help: app.translator.trans('blomstra-gdpr.admin.settings.default_anonymous_username_help'),
+    })
     .registerPermission(
       {
         icon: 'fas fa-user-minus',

--- a/js/src/admin/index.tsx
+++ b/js/src/admin/index.tsx
@@ -1,12 +1,24 @@
 import app from 'flarum/admin/app';
 import extendUserListPage from './extendUserListPage';
 import extendAdminNav from './extendAdminNav';
+import LinkButton from 'flarum/common/components/LinkButton';
 
 export { default as extend } from './extend';
 
 app.initializers.add('blomstra-gdpr', () => {
   app.extensionData
     .for('blomstra-gdpr')
+    .registerSetting(function () {
+      return (
+        <div className="Form-group">
+          <h3>{app.translator.trans('blomstra-gdpr.admin.settings.gdpr_page.title')}</h3>
+          <p className="helpText">{app.translator.trans('blomstra-gdpr.admin.settings.gdpr_page.help_text')}</p>
+          <LinkButton href={app.route('gdpr')} icon="fas fa-user-shield" className="Button">
+            {app.translator.trans('blomstra-gdpr.admin.nav.gdpr_button')}
+          </LinkButton>
+        </div>
+      );
+    })
     .registerSetting({
       setting: 'blomstra-gdpr.allow-anonymization',
       label: app.translator.trans('blomstra-gdpr.admin.settings.allow_anonymization'),

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -2,7 +2,7 @@ blomstra-gdpr:
     admin:
         gdpr_page:
             heading: GDPR Data Overview
-            description: Status of various GDPR interactions
+            description: Status of various GDPR actions and integrations
             data_types:
                 title: Data Types
                 help_text: |
@@ -23,7 +23,7 @@ blomstra-gdpr:
                     On the most part, any columns added to the <code>user</code> table will be handled automatically, both for exporting data and for erasure.
                     However, there are some special cases, which are listed below.
         nav:
-            gdpr_button: GDPR
+            gdpr_button: GDPR Integrations
         permissions:
             process_erasure: Process erasure requests
             process_export_for_others: Request and receive data exports for other users
@@ -127,7 +127,8 @@ blomstra-gdpr:
             text: |
                 Are you sure you want to erase {username}'s account?
 
-                This action is irreversible. This erasure will be processed according to the current default erasure settings.
+                This action is irreversible.
+            modal_delete_button: Erase using default action
             delete_button: Erase
         erasure_requests:
             empty_text: No pending account erasure requests

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -28,6 +28,8 @@ blomstra-gdpr:
             allow_anonymization_help: The default option, and recommended for most communities. Under this mode, posts/comments will be preserved as much as possible as allowed by GDPR, but any user identifiable information is removed.
             allow_deletion: Allow deletion for erasure requests
             allow_deletion_help: A much stricter option. Under this mode, all posts/comments will be deleted, and the user will be removed from the database. Use with caution.
+            default_anonymous_username: Default username for anonymized users
+            default_anonymous_username_help: When a user is anonymized, their username will be replaced with this value, plus the ID of the anonymization request, for example <code>Anonymous123</code>.
             default_erasure: Default action for erasure requests
             default_erasure_help: What should the default action be for erasure requests?
             default_erasure_options:

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,7 +1,7 @@
 blomstra-gdpr:
     admin:
         gdpr_page:
-            heading: GDPR Data
+            heading: GDPR Data Overview
             description: Status of various GDPR interactions
             data_types:
                 title: Data Types
@@ -13,6 +13,10 @@ blomstra-gdpr:
                 anonymize_description: Anonymize Action
                 delete_description: Delete Action
                 extension: Extension
+            settings:
+                heading: GDPR Settings
+                help_text: Looking for GDPR settings? They're found on the extension page.
+                extension_settings_button: GDPR Settings
             user_table_data:
                 title: User Table Data
                 help_text: |
@@ -35,6 +39,9 @@ blomstra-gdpr:
             default_erasure_options:
                 anonymization: Anonymization
                 deletion: Deletion
+            gdpr_page:
+                title: Data Integration and actions
+                help_text: Before deciding on which actions to use on your forum, it is vital to understand which data is integrated, and how it is handled for both anonymization and deletion. Vist the GDPR overview to understand how data is handled, and which optional extensions have registered their data to be handled by this extension.
         userlist:
             columns:
                 gdpr_actions:

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -40,10 +40,30 @@ blomstra-gdpr:
                     export: Export data for {username}
 
     lib:
+        data:
+            avatar:
+                delete_description: Deletes the user's avatar from the filesystem.
+                export_description: Retrieves the user's avatar from the filesystem and includes it in the export.
+            discussions:
+                export_description: Exports all discussions the user has started. Data restricted to title and creation date.
+            forum:
+                export_description: Exports the forum title, url, username, email and the current date.
+            no_action: No action taken.
+            posts:
+                anonymize_description: Removes the IP address from all posts the user has made.
+                delete_description: Deletes all posts the user has made.
+                export_description: Exports all posts the user has made. Data restricted to content, creation date, IP address and discussion ID.
+            tokens:
+                delete_description: Deletes all tokens the user has created.
+                export_description: Exports all tokens the user has created. Data restricted to creation date and token type.
+            user:
+                anonymize_description: Sets all columns on the user table to null. Non-nullable columns are set to their default values or special values. Password is changed, preferences set to default and all groups are removed.
+                delete_description: Deletes the user from the database.
+                export_description: Exports data from the user table. All columns except id, password.
         request_data:
             title: Request data for {username}
             text: >
-                A zip archive will be prepared for you. Once it's ready, you'll recieve a notification with a download link. The link will remain active for one day.
+                A zip archive will be prepared for you. Once it's ready, you'll receive a notification with a download link. The link will remain active for one day.
             request_button: Request archive
 
     email:

--- a/src/Api/Controller/DeleteUserController.php
+++ b/src/Api/Controller/DeleteUserController.php
@@ -33,10 +33,14 @@ class DeleteUserController extends AbstractDeleteController
     {
         $actor = RequestUtil::getActor($request);
         $user = $this->users->findOrFail(Arr::get($request->getQueryParams(), 'id'), $actor);
+        $mode = Arr::get($request->getQueryParams(), 'mode', $this->settings->get('blomstra-gdpr.default-erasure'));
+
+        if (!in_array($mode, [ErasureRequest::MODE_ANONYMIZATION, ErasureRequest::MODE_DELETION])) {
+            throw new \InvalidArgumentException('Invalid erasure mode');
+        }
 
         $actor->assertCan('delete', $user);
 
-        $mode = $this->settings->get('blomstra-gdpr.default-erasure');
 
         ErasureRequest::unguard();
 

--- a/src/Api/Controller/DeleteUserController.php
+++ b/src/Api/Controller/DeleteUserController.php
@@ -37,7 +37,7 @@ class DeleteUserController extends AbstractDeleteController
         $mode = Arr::get($request->getQueryParams(), 'mode', $this->settings->get('blomstra-gdpr.default-erasure'));
 
         if (!in_array($mode, [ErasureRequest::MODE_ANONYMIZATION, ErasureRequest::MODE_DELETION])) {
-            throw new ValidationException(["mode" => "Invalid erasure mode: {$mode}"]);
+            throw new ValidationException(['mode' => "Invalid erasure mode: {$mode}"]);
         }
 
         $actor->assertCan('delete', $user);

--- a/src/Api/Controller/DeleteUserController.php
+++ b/src/Api/Controller/DeleteUserController.php
@@ -16,6 +16,7 @@ use Blomstra\Gdpr\Jobs\GdprJob;
 use Blomstra\Gdpr\Models\ErasureRequest;
 use Carbon\Carbon;
 use Flarum\Api\Controller\AbstractDeleteController;
+use Flarum\Foundation\ValidationException;
 use Flarum\Http\RequestUtil;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\UserRepository;
@@ -36,7 +37,7 @@ class DeleteUserController extends AbstractDeleteController
         $mode = Arr::get($request->getQueryParams(), 'mode', $this->settings->get('blomstra-gdpr.default-erasure'));
 
         if (!in_array($mode, [ErasureRequest::MODE_ANONYMIZATION, ErasureRequest::MODE_DELETION])) {
-            throw new \InvalidArgumentException('Invalid erasure mode');
+            throw new ValidationException(["mode" => "Invalid erasure mode: {$mode}"]);
         }
 
         $actor->assertCan('delete', $user);

--- a/src/Api/Controller/DeleteUserController.php
+++ b/src/Api/Controller/DeleteUserController.php
@@ -41,7 +41,6 @@ class DeleteUserController extends AbstractDeleteController
 
         $actor->assertCan('delete', $user);
 
-
         ErasureRequest::unguard();
 
         $erasureRequest = ErasureRequest::firstOrNew([

--- a/src/Contracts/DataType.php
+++ b/src/Contracts/DataType.php
@@ -27,7 +27,7 @@ interface DataType
     /**
      * Description of what this data type contains.
      *
-     * @return non-empty-string
+     * @return string
      */
     public static function exportDescription(): string;
 
@@ -45,7 +45,7 @@ interface DataType
     /**
      * Description of what happens to the data when it is anonymized.
      *
-     * @return non-empty-string
+     * @return string
      */
     public static function anonymizeDescription(): string;
 
@@ -59,7 +59,7 @@ interface DataType
     /**
      * Description of what happens to the data when it is deleted.
      *
-     * @return non-empty-string
+     * @return string
      */
     public static function deleteDescription(): string;
 

--- a/src/Contracts/DataType.php
+++ b/src/Contracts/DataType.php
@@ -16,7 +16,6 @@ use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\Filesystem\Factory;
-use PhpZip\ZipFile;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 interface DataType
@@ -33,13 +32,15 @@ interface DataType
     public static function exportDescription(): string;
 
     /**
-     * Logic to add the data to the zip file.
+     * Data to be added to the zipfile.
      *
-     * @param ZipFile $zip
+     * @return array<string, string>|array<array<string, string>>|null
      *
-     * @return void
+     * - array<string, string>: Represents a single data set, e.g., ['filename.json' => '{...data...}']
+     * - array<array<string, string>>: Represents multiple data sets, e.g., [['filename1.json' => '{...data1...}'], ['filename2.json' => '{...data2...}']]
+     * - null: No data available for export.
      */
-    public function export(ZipFile $zip): void;
+    public function export(): ?array;
 
     /**
      * Description of what happens to the data when it is anonymized.

--- a/src/Data/Assets.php
+++ b/src/Data/Assets.php
@@ -12,7 +12,6 @@
 namespace Blomstra\Gdpr\Data;
 
 use Illuminate\Support\Str;
-use PhpZip\ZipFile;
 
 class Assets extends Type
 {
@@ -21,13 +20,10 @@ class Assets extends Type
         return 'Avatar';
     }
 
-    public static function exportDescription(): string
+    public function export(): ?array
     {
-        return "Retrieves the user's avatar from the filesystem and includes it in the export.";
-    }
-
-    public function export(ZipFile $zip): void
-    {
+        $dataExport = [];
+        
         if ($this->user->avatar_url) {
             $fileName = $this->getAvatarFileName();
             $fileType = Str::afterLast($fileName, '.');
@@ -37,12 +33,11 @@ class Assets extends Type
             if ($filesystem->exists($fileName)) {
                 $file = $filesystem->get($fileName);
 
-                $zip->addFromString(
-                    "avatar.$fileType",
-                    $file
-                );
+                $dataExport[] = ["avatars/avatar-{$this->user->id}.{$fileType}" => $file];
             }
         }
+
+        return $dataExport;
     }
 
     public static function anonymizeDescription(): string
@@ -54,11 +49,6 @@ class Assets extends Type
     {
         // Anonymization isn't really possible with avatars, just delete 'em.
         $this->delete();
-    }
-
-    public static function deleteDescription(): string
-    {
-        return "Deletes the user's avatar from the filesystem.";
     }
 
     public function delete(): void

--- a/src/Data/Assets.php
+++ b/src/Data/Assets.php
@@ -23,7 +23,7 @@ class Assets extends Type
     public function export(): ?array
     {
         $dataExport = [];
-        
+
         if ($this->user->avatar_url) {
             $fileName = $this->getAvatarFileName();
             $fileType = Str::afterLast($fileName, '.');

--- a/src/Data/Discussions.php
+++ b/src/Data/Discussions.php
@@ -19,7 +19,7 @@ class Discussions extends Type
     public function export(): ?array
     {
         $exportData = [];
-        
+
         Discussion::query()
             ->where('user_id', $this->user->id)
             ->whereVisibleTo($this->user)

--- a/src/Data/Forum.php
+++ b/src/Data/Forum.php
@@ -31,7 +31,6 @@ class Forum extends Type
 
         resolve(ZipManager::class)->setComment($comment);
 
-
         return ["{$forumTitle}-{$this->user->username}.txt" => $comment];
     }
 

--- a/src/Data/Forum.php
+++ b/src/Data/Forum.php
@@ -11,17 +11,12 @@
 
 namespace Blomstra\Gdpr\Data;
 
+use Blomstra\Gdpr\ZipManager;
 use Carbon\Carbon;
-use PhpZip\ZipFile;
 
 class Forum extends Type
 {
-    public static function exportDescription(): string
-    {
-        return 'Exports the forum title, url, username, email and the current date.';
-    }
-
-    public function export(ZipFile $zip): void
+    public function export(): ?array
     {
         $forumTitle = $this->settings->get('forum_title');
         $url = $this->url->to('forum')->base();
@@ -34,17 +29,10 @@ class Forum extends Type
             '{date}'       => Carbon::now()->toDateTimeString(),
         ]);
 
-        $zip->addFromString(
-            "{$forumTitle}-{$this->user->username}.txt",
-            $comment
-        );
+        resolve(ZipManager::class)->setComment($comment);
 
-        $zip->setArchiveComment($comment);
-    }
 
-    public static function anonymizeDescription(): string
-    {
-        return self::NO_ACTION_TAKEN;
+        return ["{$forumTitle}-{$this->user->username}.txt" => $comment];
     }
 
     public function anonymize(): void
@@ -52,13 +40,18 @@ class Forum extends Type
         // Nothing to do
     }
 
-    public static function deleteDescription(): string
+    public static function anonymizeDescription(): string
     {
-        return self::NO_ACTION_TAKEN;
+        return self::deleteDescription();
     }
 
     public function delete(): void
     {
         // Nothing to do
+    }
+
+    public static function deleteDescription(): string
+    {
+        return static::staticTranslator()->trans('blomstra-gdpr.lib.data.no_action');
     }
 }

--- a/src/Data/Posts.php
+++ b/src/Data/Posts.php
@@ -19,7 +19,7 @@ class Posts extends Type
     public function export(): ?array
     {
         $exportData = [];
-        
+
         Post::query()
             ->where('user_id', $this->user->id)
             ->where('type', 'comment')

--- a/src/Data/Posts.php
+++ b/src/Data/Posts.php
@@ -13,28 +13,23 @@ namespace Blomstra\Gdpr\Data;
 
 use Flarum\Post\Post;
 use Illuminate\Support\Arr;
-use PhpZip\ZipFile;
 
 class Posts extends Type
 {
-    public static function exportDescription(): string
+    public function export(): ?array
     {
-        return 'Exports all posts the user has made. Data restricted to content, creation date, IP address and discussion ID.';
-    }
-
-    public function export(ZipFile $zip): void
-    {
+        $exportData = [];
+        
         Post::query()
             ->where('user_id', $this->user->id)
             ->where('type', 'comment')
             ->whereVisibleTo($this->user)
             ->orderBy('created_at', 'asc')
-            ->each(function (Post $post) use ($zip) {
-                $zip->addFromString(
-                    "posts/post-{$post->id}.json",
-                    $this->encodeForExport($this->sanitize($post))
-                );
+            ->each(function (Post $post) use (&$exportData) {
+                $exportData[] = ["posts/post-{$post->id}.json" => $this->encodeForExport($this->sanitize($post))];
             });
+
+        return $exportData;
     }
 
     protected function sanitize(Post $post): array
@@ -45,21 +40,11 @@ class Posts extends Type
         ]);
     }
 
-    public static function anonymizeDescription(): string
-    {
-        return 'Removes the IP address from all posts the user has made.';
-    }
-
     public function anonymize(): void
     {
         Post::query()
             ->where('user_id', $this->user->id)
             ->update(['ip_address' => null]);
-    }
-
-    public static function deleteDescription(): string
-    {
-        return 'Deletes all posts the user has made.';
     }
 
     public function delete(): void

--- a/src/Data/Tokens.php
+++ b/src/Data/Tokens.php
@@ -18,7 +18,6 @@ use Flarum\User\LoginProvider;
 use Flarum\User\PasswordToken;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use PhpZip\ZipFile;
 
 class Tokens extends Type
 {
@@ -30,26 +29,23 @@ class Tokens extends Type
         PasswordToken::class,
     ];
 
-    public static function exportDescription(): string
+    public function export(): ?array
     {
-        return 'Exports all tokens the user has created. Data restricted to creation date and token type.';
-    }
-
-    public function export(ZipFile $zip): void
-    {
+        $exportData = [];
+        
         foreach ($this->classes as $class) {
             $baseName = Str::afterLast($class, '\\');
 
             $class::query()
                 ->where('user_id', $this->user->id)
-                ->each(function ($token) use ($zip, $baseName) {
+                ->each(function ($token) use ($baseName, &$exportData) {
                     $id = $token->getKey();
-                    $zip->addFromString(
-                        "tokens/token-$baseName-$id.json",
-                        json_encode(Arr::except($token->toArray(), ['user_id', 'token', 'key']), JSON_PRETTY_PRINT)
-                    );
+
+                    $exportData[] = ["tokens/token-$baseName-$id.json" => json_encode(Arr::except($token->toArray(), ['user_id', 'token', 'key']), JSON_PRETTY_PRINT)];
                 });
         }
+
+        return $exportData;
     }
 
     public static function anonymizeDescription(): string
@@ -60,11 +56,6 @@ class Tokens extends Type
     public function anonymize(): void
     {
         $this->delete();
-    }
-
-    public static function deleteDescription(): string
-    {
-        return 'Deletes all tokens the user has created.';
     }
 
     public function delete(): void

--- a/src/Data/Tokens.php
+++ b/src/Data/Tokens.php
@@ -32,7 +32,7 @@ class Tokens extends Type
     public function export(): ?array
     {
         $exportData = [];
-        
+
         foreach ($this->classes as $class) {
             $baseName = Str::afterLast($class, '\\');
 

--- a/src/Data/Type.php
+++ b/src/Data/Type.php
@@ -36,17 +36,17 @@ abstract class Type implements DataType
 
     public static function exportDescription(): string
     {
-        return self::staticTranslator()->trans("blomstra-gdpr.lib.data." . Str::lower(static::dataType()) . ".export_description");
+        return self::staticTranslator()->trans('blomstra-gdpr.lib.data.'.Str::lower(static::dataType()).'.export_description');
     }
 
     public static function anonymizeDescription(): string
     {
-        return self::staticTranslator()->trans("blomstra-gdpr.lib.data." . Str::lower(static::dataType()) . ".anonymize_description");
+        return self::staticTranslator()->trans('blomstra-gdpr.lib.data.'.Str::lower(static::dataType()).'.anonymize_description');
     }
 
     public static function deleteDescription(): string
     {
-        return self::staticTranslator()->trans("blomstra-gdpr.lib.data." . Str::lower(static::dataType()) . ".delete_description");
+        return self::staticTranslator()->trans('blomstra-gdpr.lib.data.'.Str::lower(static::dataType()).'.delete_description');
     }
 
     public static function staticTranslator(): TranslatorInterface
@@ -73,6 +73,7 @@ abstract class Type implements DataType
      * Encodes an array of data ready for export.
      *
      * @param array $data
+     *
      * @return string
      */
     protected function encodeForExport(array $data): string

--- a/src/Data/Type.php
+++ b/src/Data/Type.php
@@ -24,8 +24,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class Type implements DataType
 {
-    const NO_ACTION_TAKEN = 'No action taken.';
-
     public function __construct(
         protected User $user,
         protected ?ErasureRequest $erasureRequest,
@@ -34,6 +32,26 @@ abstract class Type implements DataType
         protected UrlGenerator $url,
         protected TranslatorInterface $translator
     ) {
+    }
+
+    public static function exportDescription(): string
+    {
+        return self::staticTranslator()->trans("blomstra-gdpr.lib.data." . Str::lower(static::dataType()) . ".export_description");
+    }
+
+    public static function anonymizeDescription(): string
+    {
+        return self::staticTranslator()->trans("blomstra-gdpr.lib.data." . Str::lower(static::dataType()) . ".anonymize_description");
+    }
+
+    public static function deleteDescription(): string
+    {
+        return self::staticTranslator()->trans("blomstra-gdpr.lib.data." . Str::lower(static::dataType()) . ".delete_description");
+    }
+
+    public static function staticTranslator(): TranslatorInterface
+    {
+        return resolve(TranslatorInterface::class);
     }
 
     public static function dataType(): string
@@ -51,6 +69,12 @@ abstract class Type implements DataType
         return $model->getConnection()->getSchemaBuilder()->getColumnListing($model->getTable());
     }
 
+    /**
+     * Encodes an array of data ready for export.
+     *
+     * @param array $data
+     * @return string
+     */
     protected function encodeForExport(array $data): string
     {
         return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);

--- a/src/Data/User.php
+++ b/src/Data/User.php
@@ -14,30 +14,16 @@ namespace Blomstra\Gdpr\Data;
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use PhpZip\ZipFile;
 
 class User extends Type
 {
-    public static function exportDescription(): string
-    {
-        return 'Exports data from the user table. All columns except id, password.';
-    }
-
-    public function export(ZipFile $zip): void
+    public function export(): ?array
     {
         $remove = ['id', 'password', 'groups'];
 
-        $zip->addFromString(
-            'user.json',
-            $this->encodeForExport(
-                Arr::except($this->user->toArray(), $remove)
-            )
-        );
-    }
-
-    public static function anonymizeDescription(): string
-    {
-        return 'Sets all columns on the user table to null. Non-nullable columns are set to their default values or special values. Password is changed, preferences set to default and all groups are removed.';
+        return ['user.json' => $this->encodeForExport(
+            Arr::except($this->user->toArray(), $remove)
+        )];
     }
 
     public function anonymize(): void
@@ -63,11 +49,6 @@ class User extends Type
         $this->user->groups()->sync([]);
 
         $this->user->save();
-    }
-
-    public static function deleteDescription(): string
-    {
-        return 'Deletes the user from the database.';
     }
 
     public function delete(): void

--- a/src/Data/User.php
+++ b/src/Data/User.php
@@ -40,7 +40,8 @@ class User extends Type
             $this->user->{$column} = null;
         }
 
-        $this->user->rename("Anonymous{$this->erasureRequest->id}");
+        $anonymousName = $this->settings->get('blomstra-gdpr.default-anonymous-username');
+        $this->user->rename("{$anonymousName}{$this->erasureRequest->id}");
         $this->user->changeEmail("{$this->user->username}@flarum-gdpr.local");
         $this->user->is_email_confirmed = false;
         $this->user->setPasswordAttribute(Str::random(40));

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -19,7 +19,6 @@ use Flarum\Notification\Notification;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\Filesystem\Factory;
-use PhpZip\ZipFile;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class Exporter
@@ -33,7 +32,8 @@ class Exporter
         protected Factory $factory,
         protected UrlGenerator $url,
         protected TranslatorInterface $translator,
-        protected StorageManager $storageManager
+        protected StorageManager $storageManager,
+        protected ZipManager $zipManager
     ) {
         $this->storagePath = $paths->storage;
     }
@@ -42,9 +42,7 @@ class Exporter
     {
         $tmpDir = $this->getTempDir();
 
-        $file = tempnam($tmpDir, 'gdpr-export-'.$user->username);
-
-        $zip = new ZipFile();
+        $file = tempnam($tmpDir, 'data-export-' . $user->username);
 
         foreach ($this->processor->removableUserColumns() as $column) {
             if ($user->{$column} !== null) {
@@ -55,12 +53,26 @@ class Exporter
         foreach ($this->processor->types() as $type => $extension) {
             /** @var DataType $segment */
             $segment = new $type($user, null, $this->factory, $this->settings, $this->url, $this->translator);
-
-            $segment->export($zip);
+    
+            $data = $segment->export();
+    
+            // Check if the array is an indexed array of associative arrays
+            if (is_array($data) && array_values($data) === $data) {
+                // Handling list of associative arrays
+                foreach ($data as $subArray) {
+                    foreach ($subArray as $filename => $content) {
+                        $this->zipManager->addData($filename, $content);
+                    }
+                }
+            } else {
+                // Handling single associative array
+                foreach ($data as $filename => $content) {
+                    $this->zipManager->addData($filename, $content);
+                }
+            }
         }
 
-        $zip->saveAsFile($file);
-        $zip->close();
+        $this->zipManager->save($file);
 
         $export = Export::exported($user, basename($file), $actor);
 
@@ -85,7 +97,7 @@ class Exporter
 
     private function getTempDir(): string
     {
-        $tmpDir = $this->storagePath.DIRECTORY_SEPARATOR.'tmp';
+        $tmpDir = $this->storagePath . DIRECTORY_SEPARATOR . 'tmp';
         if (!is_dir($tmpDir)) {
             mkdir($tmpDir, 0777, true);
         }

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -42,7 +42,7 @@ class Exporter
     {
         $tmpDir = $this->getTempDir();
 
-        $file = tempnam($tmpDir, 'data-export-' . $user->username);
+        $file = tempnam($tmpDir, 'data-export-'.$user->username);
 
         foreach ($this->processor->removableUserColumns() as $column) {
             if ($user->{$column} !== null) {
@@ -53,9 +53,9 @@ class Exporter
         foreach ($this->processor->types() as $type => $extension) {
             /** @var DataType $segment */
             $segment = new $type($user, null, $this->factory, $this->settings, $this->url, $this->translator);
-    
+
             $data = $segment->export();
-    
+
             // Check if the array is an indexed array of associative arrays
             if (is_array($data) && array_values($data) === $data) {
                 // Handling list of associative arrays
@@ -97,7 +97,7 @@ class Exporter
 
     private function getTempDir(): string
     {
-        $tmpDir = $this->storagePath . DIRECTORY_SEPARATOR . 'tmp';
+        $tmpDir = $this->storagePath.DIRECTORY_SEPARATOR.'tmp';
         if (!is_dir($tmpDir)) {
             mkdir($tmpDir, 0777, true);
         }

--- a/src/ZipManager.php
+++ b/src/ZipManager.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of blomstra/flarum-gdpr
+ *
+ * Copyright (c) 2021 Blomstra Ltd
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace Blomstra\Gdpr;
 
 use PhpZip\ZipFile;
@@ -17,7 +26,7 @@ class ZipManager
      * Add data to the ZIP file.
      *
      * @param string $filename The name of the file inside the ZIP.
-     * @param string $data The actual data/content of the file.
+     * @param string $data     The actual data/content of the file.
      */
     public function addData(string $filename, string $data): void
     {

--- a/src/ZipManager.php
+++ b/src/ZipManager.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Blomstra\Gdpr;
+
+use PhpZip\ZipFile;
+
+class ZipManager
+{
+    private ZipFile $zip;
+
+    public function __construct()
+    {
+        $this->zip = new ZipFile();
+    }
+
+    /**
+     * Add data to the ZIP file.
+     *
+     * @param string $filename The name of the file inside the ZIP.
+     * @param string $data The actual data/content of the file.
+     */
+    public function addData(string $filename, string $data): void
+    {
+        $this->zip->addFromString($filename, $data);
+    }
+
+    public function setComment(string $comment): void
+    {
+        $this->zip->setArchiveComment($comment);
+    }
+
+    /**
+     * Save the ZIP file to the specified path.
+     *
+     * @param string $path Path where the ZIP should be saved.
+     */
+    public function save(string $path): void
+    {
+        $this->zip->saveAsFile($path);
+        $this->zip->close();
+    }
+}

--- a/tests/integration/api/DeleteUserTest.php
+++ b/tests/integration/api/DeleteUserTest.php
@@ -64,7 +64,7 @@ class DeleteUserTest extends TestCase
         $response = $this->send(
             $this->request(
                 'DELETE',
-                '/api/users/2/' . ErasureRequest::MODE_ANONYMIZATION,
+                '/api/users/2/'.ErasureRequest::MODE_ANONYMIZATION,
                 [
                     'authenticatedAs' => 1,
                 ]
@@ -87,7 +87,7 @@ class DeleteUserTest extends TestCase
         $response = $this->send(
             $this->request(
                 'DELETE',
-                '/api/users/2/' . ErasureRequest::MODE_DELETION,
+                '/api/users/2/'.ErasureRequest::MODE_DELETION,
                 [
                     'authenticatedAs' => 1,
                 ]
@@ -97,7 +97,7 @@ class DeleteUserTest extends TestCase
         $this->assertEquals(422, $response->getStatusCode());
 
         $data = json_decode($response->getBody()->getContents(), true);
-        
+
         $this->assertEquals('validation_error', $data['errors'][0]['code']);
         $this->assertEquals('/data/attributes/mode', $data['errors'][0]['source']['pointer']);
     }
@@ -108,11 +108,11 @@ class DeleteUserTest extends TestCase
     public function delete_user_endpoint_can_be_called_with_deletion_mode_enabled()
     {
         $this->setting('blomstra-gdpr.allow-deletion', true);
-        
+
         $response = $this->send(
             $this->request(
                 'DELETE',
-                '/api/users/2/' . ErasureRequest::MODE_DELETION,
+                '/api/users/2/'.ErasureRequest::MODE_DELETION,
                 [
                     'authenticatedAs' => 1,
                 ]

--- a/tests/integration/api/DeleteUserTest.php
+++ b/tests/integration/api/DeleteUserTest.php
@@ -124,4 +124,28 @@ class DeleteUserTest extends TestCase
         $user = User::query()->where('id', 2)->first();
         $this->assertNull($user);
     }
+
+    /**
+     * @test
+     */
+    public function invalid_erasure_mode_throws_validation_error()
+    {
+        $response = $this->send(
+            $this->request(
+                'DELETE',
+                '/api/users/2/invalid-mode',
+                [
+                    'authenticatedAs' => 1,
+                ]
+            )
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertEquals('validation_error', $data['errors'][0]['code']);
+        $this->assertEquals('/data/attributes/mode', $data['errors'][0]['source']['pointer']);
+        $this->assertStringContainsString('invalid-mode', $data['errors'][0]['detail']);
+    }
 }

--- a/tests/integration/api/ExportTest.php
+++ b/tests/integration/api/ExportTest.php
@@ -218,7 +218,7 @@ class ExportTest extends TestCase
         $fileName = $export->file;
 
         $this->assertEquals(2, $export->user_id);
-        $this->assertStringStartsWith("gdpr-export-{$user->username}", $fileName);
+        $this->assertStringStartsWith("data-export-{$user->username}", $fileName);
     }
 
     /**

--- a/tests/integration/api/ProcessErasureTest.php
+++ b/tests/integration/api/ProcessErasureTest.php
@@ -209,6 +209,36 @@ class ProcessErasureTest extends TestCase
     /**
      * @test
      */
+    public function anonymization_with_custom_username_works()
+    {
+        $this->setting('blomstra-gdpr.default-anonymous-username', 'Custom');
+
+        $response = $this->send(
+            $this->request('PATCH', '/api/user-erasure-requests/2', [
+                'authenticatedAs' => 3,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'processor_comment' => 'I have processed this request',
+                            'meta'              => [
+                                'mode' => ErasureRequest::MODE_ANONYMIZATION,
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $user = User::where('id', 5)->with('groups')->first();
+        $this->assertNotNull($user);
+        $this->assertEquals('Custom2', $user->username);
+    }
+
+    /**
+     * @test
+     */
     public function authorized_user_cannot_process_confirmed_erasure_request_in_anonymization_mode_if_not_allowed()
     {
         $this->setting('blomstra-gdpr.allow-anonymization', false);

--- a/tests/unit/TypeTest.php
+++ b/tests/unit/TypeTest.php
@@ -21,7 +21,6 @@ use Flarum\User\User;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Mockery as m;
-use PhpZip\ZipFile;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class TypeTest extends TestCase

--- a/tests/unit/TypeTest.php
+++ b/tests/unit/TypeTest.php
@@ -185,7 +185,8 @@ class TestableType extends Type
         return '';
     }
 
-    public function export(ZipFile $zip): void
+    public function export(): ?array
     {
+        return [];
     }
 }


### PR DESCRIPTION
This will become `0.1.0-beta.18`

- Translatable action descriptions
- Rename ext to `GDPR Data Management`
- Create `ZipManager` to abstract zip operations
- Admin setting to define the anonimization username
- Link between GDPR Integrations and GDPR settings
- Allow admin to choose deletion method on user direct delete, depending on settings