### PR TITLE
docs: fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This extension allows users increasing control over their data.
 Install manually with composer:
 
 ```sh
-composer require flarum/gdpr:@beta
+composer require flarum/gdpr:^1.0.0@beta
 ```
 
 ### Use


### PR DESCRIPTION
For some reason, when I try to install this extension, Composer installs [0.1.0-beta.20](https://github.com/flarum/gdpr/releases/tag/0.1.0-beta.20).
This PR ensures that users install the latest beta version.
Installing the older version causes database migration issues when migrating from blomstra/gdpr, which prevents the extension from being enabled.