### PR TITLE
chore: minor admin frontend cleanup

### DIFF
--- a/js/src/admin/extendAdminNav.tsx
+++ b/js/src/admin/extendAdminNav.tsx
@@ -9,7 +9,7 @@ export default function extendAdminNav() {
   extend(AdminNav.prototype, 'items', function (items: ItemList<Mithril.Children>) {
     items.add(
       'gdpr',
-      <LinkButton href={app.route('gdpr')} icon="fas fa-user-shield" title={app.translator.trans('flarum-gdpr.admin.gdpr.title')}>
+      <LinkButton href={app.route('gdpr')} icon="fas fa-user-shield" title={app.translator.trans('flarum-gdpr.admin.nav.gdpr_title')}>
         {app.translator.trans('flarum-gdpr.admin.nav.gdpr_button')}
       </LinkButton>,
       48

--- a/js/src/admin/extendUserListPage.tsx
+++ b/js/src/admin/extendUserListPage.tsx
@@ -2,7 +2,6 @@ import app from 'flarum/admin/app';
 import { extend } from 'flarum/common/extend';
 import UserListPage from 'flarum/admin/components/UserListPage';
 import Button from 'flarum/common/components/Button';
-import username from 'flarum/common/helpers/username';
 import RequestDataExportModal from '../common/components/RequestDataExportModal';
 
 import type User from 'flarum/common/models/User';
@@ -14,8 +13,12 @@ export default function extendUserListPage() {
     if (!user.canModerateExports()) return;
     items.add(
       'export-data',
-      <Button icon="fas fa-file-export" onclick={() => app.modal.show(RequestDataExportModal, { user: user })}>
-        {app.translator.trans('flarum-gdpr.admin.userlist.columns.gdpr_actions.export', { username: username(user) })}
+      <Button
+        icon="fas fa-file-export"
+        title={app.translator.trans('flarum-gdpr.admin.userlist.columns.user_actions.data_export.tooltip', { username: user.displayName() })}
+        onclick={() => app.modal.show(RequestDataExportModal, { user: user })}
+      >
+        {app.translator.trans('flarum-gdpr.admin.userlist.columns.user_actions.data_export.button')}
       </Button>
     );
   });

--- a/js/src/admin/extendUserListPage.tsx
+++ b/js/src/admin/extendUserListPage.tsx
@@ -15,7 +15,7 @@ export default function extendUserListPage() {
       'export-data',
       <Button
         icon="fas fa-file-export"
-        title={app.translator.trans('flarum-gdpr.admin.userlist.columns.user_actions.data_export.tooltip', { username: user.displayName() })}
+        title={app.translator.trans('flarum-gdpr.admin.userlist.columns.user_actions.data_export.tooltip', { username: user.displayName() }, true)}
         onclick={() => app.modal.show(RequestDataExportModal, { user: user })}
       >
         {app.translator.trans('flarum-gdpr.admin.userlist.columns.user_actions.data_export.button')}

--- a/js/src/admin/extendUserListPage.tsx
+++ b/js/src/admin/extendUserListPage.tsx
@@ -10,7 +10,7 @@ export default function extendUserListPage() {
     if (!user.canModerateExports()) return;
     items.add(
       'export-data',
-      <Button className="Button" icon="fas fa-file-export" onclick={() => app.modal.show(RequestDataExportModal, { user: user })}>
+      <Button icon="fas fa-file-export" onclick={() => app.modal.show(RequestDataExportModal, { user: user })}>
         {app.translator.trans('flarum-gdpr.admin.userlist.columns.gdpr_actions.export', { username: username(user) })}
       </Button>
     );

--- a/js/src/admin/extendUserListPage.tsx
+++ b/js/src/admin/extendUserListPage.tsx
@@ -5,8 +5,12 @@ import Button from 'flarum/common/components/Button';
 import username from 'flarum/common/helpers/username';
 import RequestDataExportModal from '../common/components/RequestDataExportModal';
 
+import type User from 'flarum/common/models/User';
+import type ItemList from 'flarum/common/utils/ItemList';
+import type Mithril from 'mithril';
+
 export default function extendUserListPage() {
-  extend(UserListPage.prototype, 'userActionItems', function (items, user) {
+  extend(UserListPage.prototype, 'userActionItems', function (items: ItemList<Mithril.Children>, user: User) {
     if (!user.canModerateExports()) return;
     items.add(
       'export-data',

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -48,8 +48,10 @@ flarum-gdpr:
                 help_text: Before deciding on which actions to use on your forum, it is vital to understand which data is integrated, and how it is handled for both anonymization and deletion. Vist the GDPR overview to understand how data is handled, and which optional extensions have registered their data to be handled by this extension.
         userlist:
             columns:
-                gdpr_actions:
-                    export: Export data for {username}
+                user_actions:
+                    data_export:
+                        button: Export
+                        tooltip: Export data for {username}
 
     lib:
         data:

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -25,6 +25,8 @@ flarum-gdpr:
                     However, there are some special cases, which are listed below.
         nav:
             gdpr_button: GDPR Integrations
+            gdpr_title: => flarum-gdpr.admin.gdpr_page.description
+
         permissions:
             process_erasure: Process erasure requests
             process_export_for_others: Request and receive data exports for other users


### PR DESCRIPTION
Companion to https://github.com/flarum/framework/pull/4188

**Fixes #0000**

**Changes proposed in this pull request:**
* Remove unused classname to match structure of core, ensuring the new Button inside the dropdown is left aligned
* Increase type safety
* Add `a11y` titles
* Ditch `username()` helper inside translations (reason being `[object Object]` is shown in the translation when in use, did also a brief dive into the codebase and didn't find any other occasion where the `username()` helper was used inside a translation).
* Refactor translations to better match structure of core

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
