### PR TITLE
feat: PII field declarations and anonymized context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ return [
 ];
 ```
 
-#### Exclude specific columns from the user table during export:
+#### Redacting specific user table columns from exports:
+
+By default, the `User` data type exports all columns from the `users` table except `id`, `password`, `groups`, and `anonymized`. If your extension adds a column to the `users` table that should not appear in the export (e.g. a sensitive internal token), you can register it via `removeUserColumns()`.
+
+The column's value will be **set to `null` on the in-memory user object** before the export ZIP is generated — the column still appears in `user.json` but with a `null` value. This is visible in the admin GDPR overview under "User Table Data".
+
 ```php
 use Flarum\Gdpr\Extend\UserData;
 
@@ -87,13 +92,83 @@ return [
     (new Extend\Conditional())
         ->whenExtensionEnabled('flarum-gdpr', fn () => [
             (new UserData())
-                ->removeUserColumn('column_name') // For a single column
-                ->removeUserColumns(['column1', 'column2']), // For multiple columns
+                ->removeUserColumns(['column1', 'column2']),
 
             ... other conditional extenders as required ...
         ]),
 ];
 ```
+
+#### PII fields and anonymized contexts
+
+##### What is an "anonymized context"?
+
+Some extensions need to share Flarum data with external systems — for example, publishing events to a message broker, syncing to a search index, or sending webhooks. In these scenarios there are typically two audiences:
+
+- **Full-data consumers** — internal systems that are authorised to process PII (e.g. a private analytics pipeline).
+- **Anonymized consumers** — systems where PII must not appear (e.g. a public event stream, a third-party integration, or any consumer that doesn't need identifying information).
+
+An "anonymized context" is any such output where PII keys must be redacted before the data leaves the application. For example, [glowingblue/rabbit-dispatcher](https://github.com/glowingblue/rabbit-dispatcher) publishes Flarum events to RabbitMQ on two exchanges simultaneously: one with full payloads, and one with all PII keys replaced by `[redacted]`. The PII key list comes from `flarum/gdpr` so that every registered extension's sensitive fields are automatically covered.
+
+The GDPR admin page ("User Table Data" section) shows which fields are currently registered as PII, giving admins visibility into what will be redacted.
+
+##### Declaring PII fields on your data type
+
+If your extension stores personally identifiable information, declare which keys are PII by overriding `piiFields()` on your data type class. This is the preferred approach — the declaration lives alongside your `anonymize()` logic, and the keys are automatically included in the PII registry as soon as your type is registered.
+
+```php
+use Flarum\Gdpr\Data\Type;
+
+class MyData extends Type
+{
+    public static function piiFields(): array
+    {
+        return ['custom_field', 'another_pii_field'];
+    }
+
+    // ... export(), anonymize(), delete() ...
+}
+```
+
+##### Declaring PII fields without a data type
+
+If your extension stores PII in a field that doesn't belong to any registered data type (e.g. a column on a model you don't export via GDPR), register the keys via the `UserData` extender instead:
+
+```php
+use Flarum\Gdpr\Extend\UserData;
+
+return [
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-gdpr', fn () => [
+            (new UserData())
+                ->addPiiKeysForSerialization(['custom_field', 'another_pii_field']),
+        ]),
+];
+```
+
+##### Building an anonymized context (consuming the PII list)
+
+If you are building an extension that serializes Flarum data for an external system and want to support PII redaction, resolve the PII key list from `DataProcessor` at runtime. Always check whether `flarum-gdpr` is enabled first and provide your own fallback for when it is not:
+
+```php
+use Flarum\Extension\ExtensionManager;
+use Flarum\Gdpr\DataProcessor;
+
+$extensions = resolve(ExtensionManager::class);
+
+if ($extensions->isEnabled('flarum-gdpr')) {
+    $piiKeys = resolve(DataProcessor::class)->getPiiKeysForSerialization();
+} else {
+    // Fallback covering common fields — used when flarum/gdpr is not installed.
+    $piiKeys = ['email', 'username', 'ip_address', 'last_ip_address'];
+}
+
+// Recursively redact PII from your serialized payload before sending externally.
+$anonymizedPayload = redactKeys($payload, $piiKeys);
+```
+
+`getPiiKeysForSerialization()` aggregates fields declared by all registered data types (via `piiFields()`) plus any extras registered via `addPiiKeysForSerialization()`. This means every enabled extension that participates in the GDPR registry contributes its PII fields automatically — your consumer code doesn't need to know about them individually.
+
 ### Flarum extensions
 
 These are the known extensions which offer GDPR data integration with this extension. Don't see a required extension listed? Contact the author to request it

--- a/js/src/admin/components/GdprPage.tsx
+++ b/js/src/admin/components/GdprPage.tsx
@@ -7,14 +7,20 @@ import DataType from '../models/DataType';
 import Tooltip from 'flarum/common/components/Tooltip';
 import ExtensionLink from './ExtensionLink';
 import LinkButton from 'flarum/common/components/LinkButton';
+import icon from 'flarum/common/helpers/icon';
+
+type ColumnMeta = { type: string; length: number | null; default: string | null; nullable: boolean };
+type UserColumnsData = { allColumns: Record<string, ColumnMeta>; removableColumns: string[]; piiKeys: string[] };
 
 export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> extends AdminPage<CustomAttrs> {
   gdprDataTypes: DataType[] = [];
+  userColumnsData: UserColumnsData | null = null;
 
   oninit(vnode: Mithril.Vnode<CustomAttrs, this>) {
     super.oninit(vnode);
 
     this.loadGdprDataTypes();
+    this.loadUserColumnsData();
   }
 
   headerInfo(): AdminHeaderAttrs {
@@ -35,29 +41,43 @@ export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
     });
   }
 
+  loadUserColumnsData() {
+    app
+      .request<{ data: UserColumnsData }>({
+        method: 'GET',
+        url: app.forum.attribute('apiUrl') + '/gdpr/datatypes/user-columns',
+      })
+      .then((response) => {
+        this.userColumnsData = response.data;
+        m.redraw();
+      });
+  }
+
   content(): Mithril.Children {
     if (this.loading) {
       return <LoadingIndicator />;
     }
 
+    const t = (key: string) => app.translator.trans(`flarum-gdpr.admin.gdpr_page.${key}`);
+
     return (
       <div className="GdprPage">
-        <h3>{app.translator.trans('flarum-gdpr.admin.gdpr_page.settings.heading')}</h3>
-        <p className="helpText">{app.translator.trans('flarum-gdpr.admin.gdpr_page.settings.help_text')}</p>
+        <h3>{t('settings.heading')}</h3>
+        <p className="helpText">{t('settings.help_text')}</p>
         <LinkButton className="Button" href={app.route('extension', { id: 'flarum-gdpr' })}>
-          {app.translator.trans('flarum-gdpr.admin.gdpr_page.settings.extension_settings_button')}
+          {t('settings.extension_settings_button')}
         </LinkButton>
         <hr />
-        <h3>{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.title')}</h3>
-        <p className="helpText">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.help_text')}</p>
+        <h3>{t('data_types.title')}</h3>
+        <p className="helpText">{t('data_types.help_text')}</p>
 
         <div className="GdprGrid">
           <div class="GdprGrid-row">
-            <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.type')}</div>
-            <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.export_description')}</div>
-            <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.anonymize_description')}</div>
-            <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.delete_description')}</div>
-            <div className="GdprGrid-header">{app.translator.trans('flarum-gdpr.admin.gdpr_page.data_types.extension')}</div>
+            <div className="GdprGrid-header">{t('data_types.type')}</div>
+            <div className="GdprGrid-header">{t('data_types.export_description')}</div>
+            <div className="GdprGrid-header">{t('data_types.anonymize_description')}</div>
+            <div className="GdprGrid-header">{t('data_types.delete_description')}</div>
+            <div className="GdprGrid-header">{t('data_types.extension')}</div>
           </div>
 
           {this.gdprDataTypes.map((dataType) => (
@@ -79,9 +99,61 @@ export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
           ))}
         </div>
         <hr />
-        <h3>{app.translator.trans('flarum-gdpr.admin.gdpr_page.user_table_data.title')}</h3>
-        <p className="helpText">{app.translator.trans('flarum-gdpr.admin.gdpr_page.user_table_data.help_text')}</p>
-        <div className="GdprUserColumnData">Not yet implemented</div>
+        <h3>{t('user_table_data.title')}</h3>
+        <p className="helpText">{t('user_table_data.help_text')}</p>
+
+        {this.userColumnsData ? this.userColumnTable(this.userColumnsData) : <LoadingIndicator />}
+      </div>
+    );
+  }
+
+  userColumnTable({ allColumns, removableColumns, piiKeys }: UserColumnsData): Mithril.Children {
+    const t = (key: string) => app.translator.trans(`flarum-gdpr.admin.gdpr_page.user_table_data.${key}`);
+
+    return (
+      <div className="GdprGrid GdprGrid--userColumns">
+        <div className="GdprGrid-row">
+          <div className="GdprGrid-header">{t('column')}</div>
+          <div className="GdprGrid-header">{t('type')}</div>
+          <div className="GdprGrid-header">{t('nullable')}</div>
+          <div className="GdprGrid-header">{t('pii')}</div>
+          <div className="GdprGrid-header">{t('redacted_on_export')}</div>
+        </div>
+
+        {Object.entries(allColumns).map(([column, meta]) => {
+          const isPii = piiKeys.includes(column);
+          const isExcluded = removableColumns.includes(column);
+
+          return (
+            <div className="GdprGrid-row">
+              <div>
+                <code>{column}</code>
+              </div>
+              <div className="helpText">{meta.type}</div>
+              <div className="helpText">{meta.nullable ? t('yes') : t('no')}</div>
+              <div>
+                {isPii ? (
+                  <Tooltip text={t('pii_tooltip')}>
+                    <span className="GdprPiiBadge">
+                      {icon('fas fa-user-secret')} {t('yes')}
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <span className="helpText">{t('no')}</span>
+                )}
+              </div>
+              <div>
+                {isExcluded ? (
+                  <Tooltip text={t('redacted_on_export_tooltip')}>
+                    <span>{t('yes')}</span>
+                  </Tooltip>
+                ) : (
+                  <span className="helpText">{t('no')}</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/js/src/admin/components/GdprPage.tsx
+++ b/js/src/admin/components/GdprPage.tsx
@@ -10,7 +10,12 @@ import LinkButton from 'flarum/common/components/LinkButton';
 import icon from 'flarum/common/helpers/icon';
 
 type ColumnMeta = { type: string; length: number | null; default: string | null; nullable: boolean };
-type UserColumnsData = { allColumns: Record<string, ColumnMeta>; removableColumns: string[]; piiKeys: string[] };
+type UserColumnsData = {
+  allColumns: Record<string, ColumnMeta>;
+  removableColumns: Record<string, string | null>;
+  piiKeys: string[];
+  piiKeyExtensions: Record<string, string | null>;
+};
 
 export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> extends AdminPage<CustomAttrs> {
   gdprDataTypes: DataType[] = [];
@@ -107,7 +112,7 @@ export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
     );
   }
 
-  userColumnTable({ allColumns, removableColumns, piiKeys }: UserColumnsData): Mithril.Children {
+  userColumnTable({ allColumns, removableColumns, piiKeys, piiKeyExtensions }: UserColumnsData): Mithril.Children {
     const t = (key: string) => app.translator.trans(`flarum-gdpr.admin.gdpr_page.user_table_data.${key}`);
 
     return (
@@ -118,11 +123,14 @@ export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
           <div className="GdprGrid-header">{t('nullable')}</div>
           <div className="GdprGrid-header">{t('pii')}</div>
           <div className="GdprGrid-header">{t('redacted_on_export')}</div>
+          <div className="GdprGrid-header">{t('extension')}</div>
         </div>
 
         {Object.entries(allColumns).map(([column, meta]) => {
           const isPii = piiKeys.includes(column);
-          const isExcluded = removableColumns.includes(column);
+          const redactedByExtension = column in removableColumns ? removableColumns[column] : undefined;
+          const isRedacted = redactedByExtension !== undefined;
+          const extensionId = redactedByExtension ?? (column in piiKeyExtensions ? piiKeyExtensions[column] : null);
 
           return (
             <div className="GdprGrid-row">
@@ -143,13 +151,16 @@ export default class GdprPage<CustomAttrs extends IPageAttrs = IPageAttrs> exten
                 )}
               </div>
               <div>
-                {isExcluded ? (
+                {isRedacted ? (
                   <Tooltip text={t('redacted_on_export_tooltip')}>
                     <span>{t('yes')}</span>
                   </Tooltip>
                 ) : (
                   <span className="helpText">{t('no')}</span>
                 )}
+              </div>
+              <div>
+                <ExtensionLink extension={extensionId ? (app.data.extensions[extensionId] ?? null) : null} />
               </div>
             </div>
           );

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -38,11 +38,24 @@
         background-color: @control-bg;
         color: @control-color;
         border-bottom: 1px solid @muted-color;
-  
+
         > div {
           background-color: @control-bg;
         }
       }
     }
+
+    .GdprGrid--userColumns {
+      .GdprGrid-row {
+        grid-template-columns: 2fr 1fr 1fr 1fr 1.5fr;
+      }
+    }
+
+    .GdprPiiBadge {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      color: @primary-color;
+      font-weight: 600;
+    }
   }
-  

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -47,7 +47,7 @@
 
     .GdprGrid--userColumns {
       .GdprGrid-row {
-        grid-template-columns: 2fr 1fr 1fr 1fr 1.5fr;
+        grid-template-columns: 2fr 1fr 1fr 1fr 1fr 1fr;
       }
     }
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -22,6 +22,15 @@ flarum-gdpr:
                 help_text: |
                     On the most part, any columns added to the <code>user</code> table will be handled automatically, both for exporting data and for erasure.
                     However, there are some special cases, which are listed below.
+                column: Column
+                type: Type
+                nullable: Nullable
+                pii: PII
+                redacted_on_export: Redacted on export
+                yes: Yes
+                no: No
+                pii_tooltip: This column is considered personally identifiable information and will be redacted in anonymized contexts (e.g. anonymized event payloads).
+                redacted_on_export_tooltip: This column's value is blanked (set to null) when generating a user data export. The column still appears in the export with a null value.
         nav:
             gdpr_button: GDPR Integrations
         permissions:

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -27,6 +27,7 @@ flarum-gdpr:
                 nullable: Nullable
                 pii: PII
                 redacted_on_export: Redacted on export
+                extension: Extension
                 yes: Yes
                 no: No
                 pii_tooltip: This column is considered personally identifiable information and will be redacted in anonymized contexts (e.g. anonymized event payloads).

--- a/src/Api/Controller/ListUserColumnsDataController.php
+++ b/src/Api/Controller/ListUserColumnsDataController.php
@@ -33,6 +33,7 @@ class ListUserColumnsDataController implements RequestHandlerInterface
             'data' => [
                 'removableColumns' => $removableColumns,
                 'allColumns'       => $allColumns,
+                'piiKeys'          => $this->processor->getPiiKeysForSerialization(),
             ],
         ]);
     }

--- a/src/Api/Controller/ListUserColumnsDataController.php
+++ b/src/Api/Controller/ListUserColumnsDataController.php
@@ -26,14 +26,14 @@ class ListUserColumnsDataController implements RequestHandlerInterface
     {
         RequestUtil::getActor($request)->assertAdmin();
 
-        $removableColumns = $this->processor->removableUserColumns();
         $allColumns = $this->processor->allUserColumns();
 
         return new JsonResponse([
             'data' => [
-                'removableColumns' => $removableColumns,
+                'removableColumns' => $this->processor->removableUserColumnsWithExtensions(),
                 'allColumns'       => $allColumns,
                 'piiKeys'          => $this->processor->getPiiKeysForSerialization(),
+                'piiKeyExtensions' => $this->processor->getExtraPiiKeysWithExtensions(),
             ],
         ]);
     }

--- a/src/Contracts/DataType.php
+++ b/src/Contracts/DataType.php
@@ -67,4 +67,13 @@ interface DataType
      * @return void
      */
     public function delete(): void;
+
+    /**
+     * Keys within this data type that contain PII.
+     * Used to redact sensitive fields when serializing for non-PII contexts
+     * (e.g. anonymized event payloads to a message broker).
+     *
+     * @return string[]
+     */
+    public static function piiFields(): array;
 }

--- a/src/Data/Posts.php
+++ b/src/Data/Posts.php
@@ -14,6 +14,11 @@ use Illuminate\Support\Arr;
 
 class Posts extends Type
 {
+    public static function piiFields(): array
+    {
+        return ['ip_address'];
+    }
+
     public function export(): ?array
     {
         $exportData = [];

--- a/src/Data/Tokens.php
+++ b/src/Data/Tokens.php
@@ -27,6 +27,11 @@ class Tokens extends Type
         PasswordToken::class,
     ];
 
+    public static function piiFields(): array
+    {
+        return ['last_ip_address'];
+    }
+
     public function export(): ?array
     {
         $exportData = [];

--- a/src/Data/Type.php
+++ b/src/Data/Type.php
@@ -57,6 +57,11 @@ abstract class Type implements DataType
         return Str::afterLast(static::class, '\\');
     }
 
+    public static function piiFields(): array
+    {
+        return [];
+    }
+
     public function getDisk(?string $name): Filesystem
     {
         return $this->factory->disk($name);

--- a/src/Data/User.php
+++ b/src/Data/User.php
@@ -15,6 +15,11 @@ use Illuminate\Support\Str;
 
 class User extends Type
 {
+    public static function piiFields(): array
+    {
+        return ['email', 'username', 'last_seen_at', 'joined_at', 'preferences'];
+    }
+
     public function export(): ?array
     {
         $remove = ['id', 'password', 'groups', 'anonymized'];

--- a/src/DataProcessor.php
+++ b/src/DataProcessor.php
@@ -32,7 +32,7 @@ final class DataProcessor
     ];
 
     /**
-     * @var string[] List of user columns to be removed.
+     * @var array<string, string|null> Map of column name => extension ID (or null for core).
      */
     private static array $removeUserColumns = [];
 
@@ -46,7 +46,7 @@ final class DataProcessor
      * data types via {@see DataType::piiFields()}. Use this only for PII fields that don't
      * belong to any registered data type.
      *
-     * @var string[]
+     * @var array<string, string|null> Map of key name => extension ID (or null for core).
      */
     private static array $extraPiiKeysForSerialization = [];
 
@@ -89,11 +89,22 @@ final class DataProcessor
     /**
      * Add columns to the list of user columns to be removed.
      *
-     * @param string[] $columns List of column names.
+     * @param string[]    $columns     List of column names.
+     * @param string|null $extensionId The ID of the extension registering the columns.
      */
-    public static function removeUserColumns(array $columns)
+    public static function removeUserColumns(array $columns, ?string $extensionId = null)
     {
-        self::$removeUserColumns = array_merge(self::$removeUserColumns, $columns);
+        foreach ($columns as $column) {
+            self::$removeUserColumns[$column] = $extensionId;
+        }
+    }
+
+    /**
+     * Reset the removable user columns list. Intended for use in tests.
+     */
+    public static function resetRemovableUserColumns(): void
+    {
+        self::$removeUserColumns = [];
     }
 
     /**
@@ -107,11 +118,21 @@ final class DataProcessor
     }
 
     /**
-     * Retrieve the list of user columns to be removed.
+     * Retrieve the list of user columns to be removed (column names only).
      *
      * @return string[] List of column names.
      */
     public function removableUserColumns(): array
+    {
+        return array_keys(self::$removeUserColumns);
+    }
+
+    /**
+     * Retrieve the full map of removable user columns with their registering extension IDs.
+     *
+     * @return array<string, string|null> Map of column name => extension ID (or null for core).
+     */
+    public function removableUserColumnsWithExtensions(): array
     {
         return self::$removeUserColumns;
     }
@@ -167,14 +188,26 @@ final class DataProcessor
      * by any registered data type. Prefer declaring PII fields on the data type itself
      * via {@see DataType::piiFields()} wherever possible.
      *
-     * @param string[] $keys
+     * @param string[]    $keys
+     * @param string|null $extensionId The ID of the extension registering the keys.
      */
-    public static function addPiiKeysForSerialization(array $keys): void
+    public static function addPiiKeysForSerialization(array $keys, ?string $extensionId = null): void
     {
-        self::$extraPiiKeysForSerialization = array_values(array_unique(array_merge(
-            self::$extraPiiKeysForSerialization,
-            $keys
-        )));
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, self::$extraPiiKeysForSerialization)) {
+                self::$extraPiiKeysForSerialization[$key] = $extensionId;
+            }
+        }
+    }
+
+    /**
+     * Retrieve the extra PII keys with their registering extension IDs.
+     *
+     * @return array<string, string|null> Map of key name => extension ID (or null for core).
+     */
+    public function getExtraPiiKeysWithExtensions(): array
+    {
+        return self::$extraPiiKeysForSerialization;
     }
 
     /**
@@ -190,6 +223,6 @@ final class DataProcessor
             ...array_map(fn (string $type) => $type::piiFields(), array_keys(self::$types))
         );
 
-        return array_values(array_unique(array_merge($fromTypes, self::$extraPiiKeysForSerialization)));
+        return array_values(array_unique(array_merge($fromTypes, array_keys(self::$extraPiiKeysForSerialization))));
     }
 }

--- a/src/DataProcessor.php
+++ b/src/DataProcessor.php
@@ -42,6 +42,15 @@ final class DataProcessor
     private static $columnActions = [];
 
     /**
+     * Additional PII keys for serialization anonymization, beyond those declared by registered
+     * data types via {@see DataType::piiFields()}. Use this only for PII fields that don't
+     * belong to any registered data type.
+     *
+     * @var string[]
+     */
+    private static array $extraPiiKeysForSerialization = [];
+
+    /**
      * Add a data type to the list.
      *
      * @param string      $class       The class name of the data type.
@@ -143,5 +152,44 @@ final class DataProcessor
     public function getColumnActions(): array
     {
         return self::$columnActions;
+    }
+
+    /**
+     * Reset the extra PII keys list. Intended for use in tests.
+     */
+    public static function resetExtraPiiKeysForSerialization(): void
+    {
+        self::$extraPiiKeysForSerialization = [];
+    }
+
+    /**
+     * Register additional PII keys for serialization anonymization that are not declared
+     * by any registered data type. Prefer declaring PII fields on the data type itself
+     * via {@see DataType::piiFields()} wherever possible.
+     *
+     * @param string[] $keys
+     */
+    public static function addPiiKeysForSerialization(array $keys): void
+    {
+        self::$extraPiiKeysForSerialization = array_values(array_unique(array_merge(
+            self::$extraPiiKeysForSerialization,
+            $keys
+        )));
+    }
+
+    /**
+     * Get the full list of PII keys for serialization anonymization.
+     * Aggregates fields declared by all registered data types, plus any extras
+     * added via {@see addPiiKeysForSerialization()}.
+     *
+     * @return string[]
+     */
+    public function getPiiKeysForSerialization(): array
+    {
+        $fromTypes = array_merge(
+            ...array_map(fn (string $type) => $type::piiFields(), array_keys(self::$types))
+        );
+
+        return array_values(array_unique(array_merge($fromTypes, self::$extraPiiKeysForSerialization)));
     }
 }

--- a/src/Extend/UserData.php
+++ b/src/Extend/UserData.php
@@ -19,6 +19,7 @@ class UserData implements ExtenderInterface
     protected array $types = [];
     protected array $removeTypes = [];
     protected array $removeUserColumns = [];
+    protected array $piiKeysForSerialization = [];
 
     public function extend(Container $container, Extension $extension = null)
     {
@@ -31,6 +32,7 @@ class UserData implements ExtenderInterface
         }
 
         DataProcessor::removeUserColumns($this->removeUserColumns);
+        DataProcessor::addPiiKeysForSerialization($this->piiKeysForSerialization);
     }
 
     /**
@@ -74,6 +76,24 @@ class UserData implements ExtenderInterface
     {
         $columns = (array) $columns;
         $this->removeUserColumns = array_merge($this->removeUserColumns, $columns);
+
+        return $this;
+    }
+
+    /**
+     * Register additional PII keys for serialization anonymization that are not covered by
+     * any registered data type. Prefer implementing {@see \Flarum\Gdpr\Contracts\DataType::piiFields()}
+     * on your data type class instead — that keeps the PII declaration co-located with the
+     * anonymization logic. Use this method only for PII fields that don't belong to any type.
+     *
+     * @param string|string[] $keys
+     *
+     * @return self
+     */
+    public function addPiiKeysForSerialization($keys): self
+    {
+        $keys = (array) $keys;
+        $this->piiKeysForSerialization = array_merge($this->piiKeysForSerialization, $keys);
 
         return $this;
     }

--- a/src/Extend/UserData.php
+++ b/src/Extend/UserData.php
@@ -31,8 +31,8 @@ class UserData implements ExtenderInterface
             DataProcessor::removeType($type);
         }
 
-        DataProcessor::removeUserColumns($this->removeUserColumns);
-        DataProcessor::addPiiKeysForSerialization($this->piiKeysForSerialization);
+        DataProcessor::removeUserColumns($this->removeUserColumns, $extension?->getId());
+        DataProcessor::addPiiKeysForSerialization($this->piiKeysForSerialization, $extension?->getId());
     }
 
     /**

--- a/tests/integration/api/ExtenderTest.php
+++ b/tests/integration/api/ExtenderTest.php
@@ -10,6 +10,7 @@
 namespace Flarum\Gdpr\Tests\integration\api;
 
 use Flarum\Gdpr\Data\Forum;
+use Flarum\Gdpr\Data\Type;
 use Flarum\Gdpr\DataProcessor;
 use Flarum\Gdpr\Extend\UserData;
 use Flarum\Testing\integration\TestCase;
@@ -103,6 +104,74 @@ class ExtenderTest extends TestCase
         $this->assertContains('another_column', $columns);
     }
 
+    /**
+     * @test
+     */
+    public function custom_pii_key_can_be_registered_via_extender()
+    {
+        $this->extend(
+            (new UserData())
+                ->addPiiKeysForSerialization('custom_pii_field')
+        );
+
+        $this->app();
+
+        $keys = $this->getDataProcessor()->getPiiKeysForSerialization();
+
+        $this->assertContains('custom_pii_field', $keys);
+    }
+
+    /**
+     * @test
+     */
+    public function multiple_custom_pii_keys_can_be_registered_via_extender()
+    {
+        $this->extend(
+            (new UserData())
+                ->addPiiKeysForSerialization(['field_a', 'field_b'])
+        );
+
+        $this->app();
+
+        $keys = $this->getDataProcessor()->getPiiKeysForSerialization();
+
+        $this->assertContains('field_a', $keys);
+        $this->assertContains('field_b', $keys);
+    }
+
+    /**
+     * @test
+     */
+    public function built_in_pii_fields_are_present_without_any_extender()
+    {
+        $this->app();
+
+        $keys = $this->getDataProcessor()->getPiiKeysForSerialization();
+
+        $this->assertContains('email', $keys);
+        $this->assertContains('username', $keys);
+        $this->assertContains('ip_address', $keys);
+        $this->assertContains('last_ip_address', $keys);
+    }
+
+    /**
+     * @test
+     */
+    public function pii_fields_from_custom_data_type_are_included()
+    {
+        $this->extend(
+            (new UserData())
+                ->addType(DataTypeWithPii::class)
+        );
+
+        $this->app();
+
+        $keys = $this->getDataProcessor()->getPiiKeysForSerialization();
+
+        $this->assertContains('bio', $keys);
+        $this->assertContains('location', $keys);
+    }
+
     protected function getDataProcessor(): DataProcessor
     {
         return $this->app()->getContainer()->make(DataProcessor::class);
@@ -114,5 +183,41 @@ class MyNewDataType
     public static function dataType(): string
     {
         return 'my-new-data-type';
+    }
+}
+
+class DataTypeWithPii extends Type
+{
+    public static function piiFields(): array
+    {
+        return ['bio', 'location'];
+    }
+
+    public static function exportDescription(): string
+    {
+        return '';
+    }
+
+    public function export(): ?array
+    {
+        return null;
+    }
+
+    public static function anonymizeDescription(): string
+    {
+        return '';
+    }
+
+    public function anonymize(): void
+    {
+    }
+
+    public static function deleteDescription(): string
+    {
+        return '';
+    }
+
+    public function delete(): void
+    {
     }
 }

--- a/tests/integration/api/ListUserColumnsDataControllerTest.php
+++ b/tests/integration/api/ListUserColumnsDataControllerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Gdpr\Tests\integration\Api;
+
+use Flarum\Gdpr\Extend\UserData;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class ListUserColumnsDataControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+
+        $this->extension('flarum-gdpr');
+    }
+
+    /**
+     * @test
+     */
+    public function non_admin_cannot_access_user_columns()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr/datatypes/user-columns', ['authenticatedAs' => 2])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function admin_can_access_user_columns()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr/datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('data', $body);
+        $this->assertArrayHasKey('allColumns', $body['data']);
+        $this->assertArrayHasKey('removableColumns', $body['data']);
+        $this->assertArrayHasKey('piiKeys', $body['data']);
+    }
+
+    /**
+     * @test
+     */
+    public function response_includes_built_in_pii_keys()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr/datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+        $piiKeys = $body['data']['piiKeys'];
+
+        $this->assertContains('email', $piiKeys);
+        $this->assertContains('username', $piiKeys);
+        $this->assertContains('last_seen_at', $piiKeys);
+        $this->assertContains('joined_at', $piiKeys);
+        $this->assertContains('preferences', $piiKeys);
+    }
+
+    /**
+     * @test
+     */
+    public function response_includes_extra_pii_keys_registered_via_extender()
+    {
+        $this->extend(
+            (new UserData())
+                ->addPiiKeysForSerialization('custom_pii_field')
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr/datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+        $piiKeys = $body['data']['piiKeys'];
+
+        $this->assertContains('custom_pii_field', $piiKeys);
+        $this->assertContains('email', $piiKeys); // built-in keys still present
+    }
+
+    /**
+     * @test
+     */
+    public function response_includes_removable_columns_registered_via_extender()
+    {
+        $this->extend(
+            (new UserData())
+                ->removeUserColumns(['my_custom_column'])
+        );
+
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr/datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertContains('my_custom_column', $body['data']['removableColumns']);
+    }
+
+    /**
+     * @test
+     */
+    public function all_columns_includes_standard_user_table_columns()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/gdpr/datatypes/user-columns', ['authenticatedAs' => 1])
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+        $allColumns = $body['data']['allColumns'];
+
+        $this->assertArrayHasKey('id', $allColumns);
+        $this->assertArrayHasKey('username', $allColumns);
+        $this->assertArrayHasKey('email', $allColumns);
+
+        // Each column entry has the expected metadata shape
+        $this->assertArrayHasKey('type', $allColumns['id']);
+        $this->assertArrayHasKey('nullable', $allColumns['id']);
+    }
+}

--- a/tests/integration/api/ListUserColumnsDataControllerTest.php
+++ b/tests/integration/api/ListUserColumnsDataControllerTest.php
@@ -117,7 +117,7 @@ class ListUserColumnsDataControllerTest extends TestCase
 
         $body = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertContains('my_custom_column', $body['data']['removableColumns']);
+        $this->assertArrayHasKey('my_custom_column', $body['data']['removableColumns']);
     }
 
     /**

--- a/tests/unit/DataProcessorTest.php
+++ b/tests/unit/DataProcessorTest.php
@@ -19,7 +19,7 @@ class DataProcessorTest extends TestCase
     {
         parent::setUp();
 
-        // Resetting the types and removeUserColumns properties before each test
+        // Resetting all static state before each test
         DataProcessor::setTypes([
             Data\Forum::class       => null,
             Data\Assets::class      => null,
@@ -29,6 +29,7 @@ class DataProcessorTest extends TestCase
             Data\User::class        => null,
         ]);
         DataProcessor::removeUserColumns([]);
+        DataProcessor::resetExtraPiiKeysForSerialization();
     }
 
     /**
@@ -110,5 +111,114 @@ class DataProcessorTest extends TestCase
         // Then
         $types = $processor->types();
         $this->assertEquals(Data\User::class, array_key_last($types));
+    }
+
+    /**
+     * @test
+     */
+    public function it_aggregates_pii_fields_from_registered_types()
+    {
+        $processor = new DataProcessor();
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        // Fields declared by built-in types
+        $this->assertContains('email', $keys);           // Data\User
+        $this->assertContains('username', $keys);        // Data\User
+        $this->assertContains('last_seen_at', $keys);    // Data\User
+        $this->assertContains('joined_at', $keys);       // Data\User
+        $this->assertContains('preferences', $keys);     // Data\User
+        $this->assertContains('ip_address', $keys);      // Data\Posts
+        $this->assertContains('last_ip_address', $keys); // Data\Tokens
+    }
+
+    /**
+     * @test
+     */
+    public function it_merges_extra_pii_keys_with_type_pii_fields()
+    {
+        $processor = new DataProcessor();
+
+        DataProcessor::addPiiKeysForSerialization(['custom_field']);
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertContains('custom_field', $keys);
+        $this->assertContains('email', $keys); // still includes type-sourced keys
+    }
+
+    /**
+     * @test
+     */
+    public function it_deduplicates_pii_keys()
+    {
+        $processor = new DataProcessor();
+
+        // 'email' is already declared by Data\User::piiFields()
+        DataProcessor::addPiiKeysForSerialization(['email', 'email', 'custom_field']);
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertCount(1, array_filter($keys, fn ($k) => $k === 'email'));
+        $this->assertCount(1, array_filter($keys, fn ($k) => $k === 'custom_field'));
+    }
+
+    /**
+     * @test
+     */
+    public function removing_a_type_removes_its_pii_fields()
+    {
+        $processor = new DataProcessor();
+
+        DataProcessor::removeType(Data\Posts::class);
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertNotContains('ip_address', $keys);
+    }
+
+    /**
+     * @test
+     */
+    public function types_with_no_pii_fields_contribute_nothing()
+    {
+        // Forum and Discussions declare no PII fields
+        DataProcessor::setTypes([
+            Data\Forum::class       => null,
+            Data\Discussions::class => null,
+        ]);
+        $processor = new DataProcessor();
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertEmpty($keys);
+    }
+
+    /**
+     * @test
+     */
+    public function extra_pii_keys_are_included_even_when_no_types_declare_pii()
+    {
+        DataProcessor::setTypes([Data\Forum::class => null]);
+        DataProcessor::addPiiKeysForSerialization(['my_field']);
+        $processor = new DataProcessor();
+
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertEquals(['my_field'], $keys);
+    }
+
+    /**
+     * @test
+     */
+    public function reset_clears_extra_pii_keys()
+    {
+        DataProcessor::addPiiKeysForSerialization(['my_field']);
+        DataProcessor::resetExtraPiiKeysForSerialization();
+
+        $processor = new DataProcessor();
+        $keys = $processor->getPiiKeysForSerialization();
+
+        $this->assertNotContains('my_field', $keys);
     }
 }

--- a/tests/unit/DataProcessorTest.php
+++ b/tests/unit/DataProcessorTest.php
@@ -28,7 +28,7 @@ class DataProcessorTest extends TestCase
             Data\Discussions::class => null,
             Data\User::class        => null,
         ]);
-        DataProcessor::removeUserColumns([]);
+        DataProcessor::resetRemovableUserColumns();
         DataProcessor::resetExtraPiiKeysForSerialization();
     }
 

--- a/tests/unit/TypeTest.php
+++ b/tests/unit/TypeTest.php
@@ -10,7 +10,10 @@
 namespace Flarum\Gdpr\Tests\unit;
 
 use Flarum\Database\AbstractModel;
+use Flarum\Gdpr\Data\Posts;
+use Flarum\Gdpr\Data\Tokens;
 use Flarum\Gdpr\Data\Type;
+use Flarum\Gdpr\Data\User as UserData;
 use Flarum\Gdpr\Models\ErasureRequest;
 use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -115,6 +118,44 @@ class TypeTest extends TestCase
 
         // Then
         $this->assertEquals('TestableType', $dataType);
+    }
+
+    /**
+     * @test
+     */
+    public function base_type_returns_empty_pii_fields()
+    {
+        $this->assertEquals([], TestableType::piiFields());
+    }
+
+    /**
+     * @test
+     */
+    public function user_data_type_declares_expected_pii_fields()
+    {
+        $fields = UserData::piiFields();
+
+        $this->assertContains('email', $fields);
+        $this->assertContains('username', $fields);
+        $this->assertContains('last_seen_at', $fields);
+        $this->assertContains('joined_at', $fields);
+        $this->assertContains('preferences', $fields);
+    }
+
+    /**
+     * @test
+     */
+    public function posts_data_type_declares_expected_pii_fields()
+    {
+        $this->assertEquals(['ip_address'], Posts::piiFields());
+    }
+
+    /**
+     * @test
+     */
+    public function tokens_data_type_declares_expected_pii_fields()
+    {
+        $this->assertEquals(['last_ip_address'], Tokens::piiFields());
     }
 
     /**


### PR DESCRIPTION
## Summary

- Adds `piiFields(): array` to the `DataType` interface so each data type co-locates its PII field declarations with its anonymization logic — no more duplicated lists
- `DataProcessor::getPiiKeysForSerialization()` aggregates PII keys dynamically from all registered types, plus any extras registered via the `UserData` extender
- `User`, `Posts`, and `Tokens` types declare their own PII fields (`email`, `username`, `last_seen_at`, `joined_at`, `preferences`, `ip_address`, `last_ip_address`)
- `ListUserColumnsDataController` now includes `piiKeys` in the response
- Admin `GdprPage` user table section fully implemented — shows column type, nullable, PII badge, and redacted-on-export status
- README documents the "anonymized contexts" pattern and how to integrate (declare `piiFields()` on a data type, or use `addPiiKeysForSerialization()` as an escape hatch)
- Unit and integration test coverage added for all new behaviour

## Test plan

- [x] Unit tests: 30/30 passing
- [x] Integration tests: 69/69 passing
- [ ] Verify admin GdprPage user table renders correctly with PII badges and redaction tooltips
- [ ] Verify a third-party extension can declare `piiFields()` on a custom `DataType` and see the keys returned by `getPiiKeysForSerialization()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)