### PR TITLE
fix: allow nullable erasure request user relationship in serializers

### DIFF
--- a/src/Api/Serializer/ExportSerializer.php
+++ b/src/Api/Serializer/ExportSerializer.php
@@ -37,12 +37,12 @@ class ExportSerializer extends AbstractSerializer
         return $attributes;
     }
 
-    protected function user($export): Relationship
+    protected function user($export): ?Relationship
     {
         return $this->hasOne($export, BasicUserSerializer::class);
     }
 
-    protected function actor($export): Relationship
+    protected function actor($export): ?Relationship
     {
         return $this->hasOne($export, BasicUserSerializer::class);
     }

--- a/src/Api/Serializer/RequestErasureSerializer.php
+++ b/src/Api/Serializer/RequestErasureSerializer.php
@@ -36,12 +36,12 @@ class RequestErasureSerializer extends AbstractSerializer
         ];
     }
 
-    protected function user($erasure_request): Relationship
+    protected function user($erasure_request): ?Relationship
     {
         return $this->hasOne($erasure_request, BasicUserSerializer::class);
     }
 
-    protected function processedBy($erasure_request): Relationship
+    protected function processedBy($erasure_request): ?Relationship
     {
         return $this->hasOne($erasure_request, BasicUserSerializer::class);
     }

--- a/src/Http/Controller/ExportController.php
+++ b/src/Http/Controller/ExportController.php
@@ -36,7 +36,7 @@ class ExportController implements RequestHandlerInterface
                 200,
                 [
                     'Content-Type'        => 'application/zip',
-                    'Content-Length'      => $this->storageManager->getStoredExportSize($export),
+                    'Content-Length'      => (string) $this->storageManager->getStoredExportSize($export),
                     'Content-Disposition' => 'attachment; filename="data-export-'.$export->user->username.'-'.$export->created_at->toIso8601String().'.zip"',
                 ]
             );

--- a/tests/integration/api/ProcessErasureTest.php
+++ b/tests/integration/api/ProcessErasureTest.php
@@ -88,6 +88,28 @@ class ProcessErasureTest extends TestCase
     /**
      * @test
      */
+    public function authorized_users_can_see_confirmed_erasure_requests_even_if_user_was_deleted()
+    {
+        $this->send($this->request('GET', '/api/forum'));
+        User::query()->where('id', 5)->delete();
+
+        $response = $this->send(
+            $this->request('GET', '/api/user-erasure-requests', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertCount(1, $json['data']);
+        $this->assertEquals(ErasureRequest::STATUS_USER_CONFIRMED, $json['data'][0]['attributes']['status']);
+    }
+
+    /**
+     * @test
+     */
     public function unauthorized_user_cannot_process_erasure_request()
     {
         $response = $this->send(


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
