### PR TITLE
fix: guard against null return from DataType::export()

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -57,6 +57,10 @@ class Exporter
 
             $data = $segment->export();
 
+            if ($data === null) {
+                continue;
+            }
+
             // Check if the array is an indexed array of associative arrays
             if (is_array($data) && array_values($data) === $data) {
                 // Handling list of associative arrays


### PR DESCRIPTION
## Summary

- `DataType::export()` is declared `?array` in the contract, so extension-provided types may legitimately return `null` (meaning "nothing to export for this user")
- The `Exporter` did not handle this case — `is_array(null)` returns `false`, so execution fell into the `else` branch and attempted `foreach (null as ...)`, triggering a PHP warning
- Add a `continue` guard to skip `null` returns cleanly

Identified trigger: `fof/user-bio`'s `UserBioData::export()` explicitly returns `null` since the bio column is already included in the core user export.

## Test plan

- [ ] Trigger a data export for a user on a forum with `fof/user-bio` enabled — no PHP warning should appear in the log
- [ ] Verify the export zip is generated successfully and contains the expected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)