### PR TITLE
fix: preserve user locale for erasure completion email

### DIFF
--- a/src/Http/Controller/ExportController.php
+++ b/src/Http/Controller/ExportController.php
@@ -36,7 +36,7 @@ class ExportController implements RequestHandlerInterface
                 200,
                 [
                     'Content-Type'        => 'application/zip',
-                    'Content-Length'      => $this->storageManager->getStoredExportSize($export),
+                    'Content-Length'      => (string) $this->storageManager->getStoredExportSize($export),
                     'Content-Disposition' => 'attachment; filename="data-export-'.$export->user->username.'-'.$export->created_at->toIso8601String().'.zip"',
                 ]
             );

--- a/src/Jobs/ErasureJob.php
+++ b/src/Jobs/ErasureJob.php
@@ -16,6 +16,7 @@ use Flarum\Gdpr\Events\Erasing;
 use Flarum\Gdpr\Models\ErasureRequest;
 use Flarum\Gdpr\Notifications\ErasureCompletedBlueprint;
 use Flarum\Http\UrlGenerator;
+use Flarum\Locale\Translator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -87,6 +88,7 @@ class ErasureJob extends GdprJob
         // Capture the user's locale on the shared translator before
         // anonymization wipes their preferences. The completion email below
         // re-uses the same translator instance, so this carries through.
+        /** @var TranslatorInterface&Translator $translator */
         $translator->setLocale($user->getPreference('locale') ?? $this->settings->get('default_locale'));
 
         $this->{$mode}($user, $processor);

--- a/src/Jobs/ErasureJob.php
+++ b/src/Jobs/ErasureJob.php
@@ -84,6 +84,11 @@ class ErasureJob extends GdprJob
             $this->erasureRequest
         ));
 
+        // Capture the user's locale on the shared translator before
+        // anonymization wipes their preferences. The completion email below
+        // re-uses the same translator instance, so this carries through.
+        $translator->setLocale($user->getPreference('locale') ?? $this->settings->get('default_locale'));
+
         $this->{$mode}($user, $processor);
 
         $this->sendUserConfirmation($mode, $username, $email, $mailer, $translator);


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
